### PR TITLE
F1.4 ampliar datos serie

### DIFF
--- a/app/controllers/SerieController.java
+++ b/app/controllers/SerieController.java
@@ -5,6 +5,8 @@ import play.libs.Json;
 import play.db.jpa.Transactional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import json.SerieViews;
 import models.Serie;
 import models.service.SerieService;
 import java.util.ArrayList;
@@ -13,15 +15,32 @@ import java.util.List;
 public class SerieController extends Controller {
 
   // devolver todas las series (NOTE: futura paginacion?)
+  // JSON View SeriesView.SearchSerie: vista que solo incluye los campos
+  // relevante de una búsqueda
   @Transactional(readOnly = true)
   public Result all() {
     List<Serie> series = SerieService.all();
+
+    // si la lista está vacía, not found
     if (series.isEmpty()) {
       ObjectNode result = Json.newObject();
       result.put("error", "Not found");
       return notFound(result);
     }
-    return ok(Json.toJson(series));
+
+    // si la lista no está vacía, devolvemos datos
+    try {
+      JsonNode jsonNode = Json.parse(new ObjectMapper()
+                                  .writerWithView(SerieViews.SearchSerie.class)
+                                  .writeValueAsString(series));
+      return ok(jsonNode);
+
+    } catch (Exception ex) {
+      // si hubiese un error, devolver error interno
+      ObjectNode result = Json.newObject();
+      result.put("error", "It can't be processed");
+      return internalServerError(result);
+    }
   }
 
   // devolver una serie por id
@@ -33,19 +52,47 @@ public class SerieController extends Controller {
       result.put("error", "Not found");
       return notFound(result);
     }
-    return ok(Json.toJson(serie));
+
+    // si la lista no está vacía, devolvemos datos
+    try {
+      JsonNode jsonNode = Json.parse(new ObjectMapper()
+                                  .writerWithView(SerieViews.FullSerie.class)
+                                  .writeValueAsString(serie));
+      return ok(jsonNode);
+
+    } catch (Exception ex) {
+      // si hubiese un error, devolver error interno
+      ObjectNode result = Json.newObject();
+      result.put("error", "It can't be processed");
+      return internalServerError(result);
+    }
   }
 
   // devolver la busqueda de series LIKE
   @Transactional(readOnly = true)
   public Result searchSeriesNameLike(String query) {
     List<Serie> series = SerieService.findBy("seriesName", query, false);
+
+    // si la lista está vacía, not found
     if (series.isEmpty()) {
       ObjectNode result = Json.newObject();
       result.put("error", "Not found");
       return notFound(result);
     }
-    return ok(Json.toJson(series));
+
+    // si la lista no está vacía, devolvemos datos
+    try {
+      JsonNode jsonNode = Json.parse(new ObjectMapper()
+                                  .writerWithView(SerieViews.SearchSerie.class)
+                                  .writeValueAsString(series));
+      return ok(jsonNode);
+
+    } catch (Exception ex) {
+      // si hubiese un error, devolver error interno
+      ObjectNode result = Json.newObject();
+      result.put("error", "It can't be processed");
+      return internalServerError(result);
+    }
   }
 
 }

--- a/app/json/SerieViews.java
+++ b/app/json/SerieViews.java
@@ -1,0 +1,7 @@
+package json;
+
+public class SerieViews {
+  public static class SearchSerie {}
+  public static class FullSerie extends SearchSerie {}
+  public static class InternalFullSerie extends FullSerie {}
+}

--- a/app/models/Serie.java
+++ b/app/models/Serie.java
@@ -64,6 +64,18 @@ public class Serie {
   @JsonView(SerieViews.FullSerie.class)
   public Status status;
 
+  @JsonView(SerieViews.FullSerie.class)
+  public String writer;
+
+  @JsonView(SerieViews.FullSerie.class)
+  public String actors;
+
+  @JsonView(SerieViews.FullSerie.class)
+  public Float imdbRating;
+
+  @JsonView(SerieViews.FullSerie.class)
+  public String trailer;
+
   // constructor vacio
   public Serie() {}
 
@@ -71,7 +83,8 @@ public class Serie {
   public Serie(Integer idTVDB, String seriesName, Date firstAired,
               String overview, String banner, String poster, String fanart,
               String network, Integer runtime, Set<String> genre,
-              String rating, Status status) {
+              String rating, Status status, String writer, String actors,
+              Float imdbRating, String trailer) {
 
     this.idTVDB = idTVDB;
     this.seriesName = seriesName;
@@ -85,6 +98,10 @@ public class Serie {
     this.genre = genre;
     this.rating = rating;
     this.status = status;
+    this.writer = writer;
+    this.actors = actors;
+    this.imdbRating = imdbRating;
+    this.trailer = trailer;
   }
 
   // contructor copia
@@ -101,8 +118,13 @@ public class Serie {
     this.genre = serie.genre;
     this.rating = serie.rating;
     this.status = serie.status;
+    this.writer = serie.writer;
+    this.actors = serie.actors;
+    this.imdbRating = serie.imdbRating;
+    this.trailer = serie.trailer;
   }
 
+  // solo informacion importante
   @Override
   public String toString() {
     return "Serie [id=" + id + ", idTVDB=" + idTVDB + ", seriesName="

--- a/app/models/Serie.java
+++ b/app/models/Serie.java
@@ -8,6 +8,8 @@ import java.util.Set;
 import java.util.HashSet;
 import play.data.validation.Constraints;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.*;
+import json.SerieViews;
 
 @Entity
 @Table(name = "serie")
@@ -16,25 +18,50 @@ public class Serie {
 
   @Id
   @GeneratedValue(strategy=GenerationType.IDENTITY)
+  @JsonView(SerieViews.SearchSerie.class)
   public Integer id;
+
+  @JsonView(SerieViews.InternalFullSerie.class)
   public Integer idTVDB;
+
   @Column(length = 100)
+  @JsonView(SerieViews.SearchSerie.class)
   public String seriesName;
+
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  @JsonView(SerieViews.SearchSerie.class)
   public Date firstAired;
+
   @Column(columnDefinition = "text")
+  @JsonView(SerieViews.FullSerie.class)
   public String overview;
+
+  @JsonView(SerieViews.SearchSerie.class)
   public String banner;
+
+  @JsonView(SerieViews.FullSerie.class)
   public String poster;
+
+  @JsonView(SerieViews.FullSerie.class)
   public String fanart;
+
   @Column(length = 50)
+  @JsonView(SerieViews.FullSerie.class)
   public String network;
+
+  @JsonView(SerieViews.FullSerie.class)
   public Integer runtime;
+
+  @JsonView(SerieViews.FullSerie.class)
   @ElementCollection
   public Set<String> genre = new HashSet();
+
+  @JsonView(SerieViews.FullSerie.class)
   public String rating;
+
   // NOTE: error con H2 en test @Column(columnDefinition = "enum('Continuing', 'Ended')")
   @Enumerated(EnumType.STRING)
+  @JsonView(SerieViews.FullSerie.class)
   public Status status;
 
   // constructor vacio

--- a/app/models/Serie.java
+++ b/app/models/Serie.java
@@ -2,6 +2,10 @@ package models;
 
 import javax.persistence.*;
 import java.util.Date;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Set;
+import java.util.HashSet;
 import play.data.validation.Constraints;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -21,8 +25,14 @@ public class Serie {
   @Column(columnDefinition = "text")
   public String overview;
   public String banner;
+  public String poster;
+  public String fanart;
   @Column(length = 50)
   public String network;
+  public Integer runtime;
+  @ElementCollection
+  public Set<String> genre = new HashSet();
+  public String rating;
   // NOTE: error con H2 en test @Column(columnDefinition = "enum('Continuing', 'Ended')")
   @Enumerated(EnumType.STRING)
   public Status status;
@@ -32,14 +42,21 @@ public class Serie {
 
   // contructor por campos
   public Serie(Integer idTVDB, String seriesName, Date firstAired,
-              String overview, String banner, String network, Status status) {
+              String overview, String banner, String poster, String fanart,
+              String network, Integer runtime, Set<String> genre,
+              String rating, Status status) {
 
     this.idTVDB = idTVDB;
     this.seriesName = seriesName;
     this.firstAired = firstAired;
     this.overview = overview;
     this.banner = banner;
+    this.poster = poster;
+    this.fanart = fanart;
     this.network = network;
+    this.runtime = runtime;
+    this.genre = genre;
+    this.rating = rating;
     this.status = status;
   }
 
@@ -50,7 +67,12 @@ public class Serie {
     this.firstAired = serie.firstAired;
     this.overview = serie.overview;
     this.banner = serie.banner;
+    this.poster = serie.poster;
+    this.fanart = serie.fanart;
     this.network = serie.network;
+    this.runtime = serie.runtime;
+    this.genre = serie.genre;
+    this.rating = serie.rating;
     this.status = serie.status;
   }
 
@@ -58,7 +80,7 @@ public class Serie {
   public String toString() {
     return "Serie [id=" + id + ", idTVDB=" + idTVDB + ", seriesName="
             + seriesName + ", firstAired=" + firstAired + ", overview="
-            + overview + ", banner=" + banner + ", network=" + network
+            + overview + ", network=" + network
             + ", status=" + status + "]";
   }
 }

--- a/docs/api-doc-versions/v0.0.2-not-try.yaml
+++ b/docs/api-doc-versions/v0.0.2-not-try.yaml
@@ -219,3 +219,15 @@ definitions:
       status:
         type: string
         description: status of the series (continuing or ended)
+      writer:
+        type: string
+        description: writer or writers of the series
+      actors:
+        type: string
+        description: principal actors of the series
+      imdbRating:
+        type: float
+        description: average rating on imdb of the series
+      trailer:
+        type: string
+        description: YouTube video code of the trailer

--- a/docs/api-doc-versions/v0.0.2-not-try.yaml
+++ b/docs/api-doc-versions/v0.0.2-not-try.yaml
@@ -1,0 +1,221 @@
+# Example YAML to get you started quickly.
+# Be aware that YAML has indentation based scoping.
+# Code completion support is available so start typing for available options.
+swagger: '2.0'
+
+# This is your document metadata
+info:
+  version: "0.0.2"
+  title: TFG Trending Series v0 `Offline`
+  description: >-
+    The API is accessible via https://darkhollow.github.com/tfg-series-playAPI/
+    and provides the following `REST` endpoints in `JSON` format.
+
+
+
+    How to use this API documentation
+
+    ----------------
+
+
+
+    You may browse the API routes freely without any authentication.
+
+
+    You will **NOT** be able to use the routes to send requests to the API and
+    get a response because this is a `Offline Documentation` for `Github Pages`.
+
+    Because of that, the button `Try it out` is disabled in all the routes.
+
+
+
+    Versioning
+
+    ----------------
+
+
+
+    This documentation automatically uses the version seen at the top and
+    bottom of the page.
+
+
+
+    About this project
+
+    ----------------
+
+
+
+    This [API](https://github.com/DarkHollow/tfg-series-playAPI) and API documentation is part of a `TFG (Final Degree Project)`
+    of Software Engineering by [Roberto Cánovas ![Github](images/github-logo.png)](https://github.com/DarkHollow/) at
+    the University of Alicante (Spain). You can contact me at [Github](https://github.com/DarkHollow/), [e-mail](mailto: rcanovas.corp@gmail.com) or [Twitter](https://twitter.com/RobCanovas).
+
+    ### Status: work in progress
+
+
+basePath: /api
+tags:
+  - name: root
+    description: Status
+  - name: Search
+    description: Search for series
+  - name: Series
+    description: Information about a specific series
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /:
+    get:
+      tags:
+        - root
+      description: >-
+        Returns the status of the API and a link to the documentation
+      responses:
+        '200':
+          description: JSON response with status and doc link keys
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: status of the API
+              API_doc:
+                type: string
+                description: link to the documentation
+  /search/series/{name}:
+    get:
+      tags:
+        - Search
+      description: >-
+        Allows the user to search for series based on its name (can be partially)
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Name of the series to search for
+          type: string
+      responses:
+        '200':
+          description: JSON response with an array of all results that match partially or exact
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns basic information about all series (will be deprecated)
+      responses:
+        '200':
+          description: JSON response with an array of all series
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series/{id}:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns all information about a particular series by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the series
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the series
+          schema:
+            $ref: '#/definitions/Series'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+definitions:
+  NotFound:
+    properties:
+      error:
+        type: string
+  InternalServerError:
+    properties:
+      error:
+        type: string
+  SeriesArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: series id
+        seriesName:
+          type: string
+          description: name of the series
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+  Series:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: series id
+      seriesName:
+        type: string
+        description: name of the series
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the series
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the series airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the series
+      status:
+        type: string
+        description: status of the series (continuing or ended)

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "api-doc-versions/v0.0.1-not-try.yaml";
+        url = "api-doc-versions/v0.0.2-not-try.yaml";
       }
 
       hljs.configure({
@@ -91,7 +91,7 @@
 <body class="swagger-section">
 <div id='header'>
   <div class="swagger-ui-wrap">
-    <a id="logo" href="docs"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.0.1)</span></a>
+    <a id="logo" href="tfg-series-playAPI"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.0.2)</span></a>
     <!--<form id='api_selector'>
       <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
       <div id='auth_container'></div>

--- a/public/doc/api-doc-versions/v0.0.2.yaml
+++ b/public/doc/api-doc-versions/v0.0.2.yaml
@@ -217,3 +217,15 @@ definitions:
       status:
         type: string
         description: status of the series (continuing or ended)
+      writer:
+        type: string
+        description: writer or writers of the series
+      actors:
+        type: string
+        description: principal actors of the series
+      imdbRating:
+        type: float
+        description: average rating on imdb of the series
+      trailer:
+        type: string
+        description: YouTube video code of the trailer

--- a/public/doc/api-doc-versions/v0.0.2.yaml
+++ b/public/doc/api-doc-versions/v0.0.2.yaml
@@ -1,0 +1,219 @@
+# Example YAML to get you started quickly.
+# Be aware that YAML has indentation based scoping.
+# Code completion support is available so start typing for available options.
+swagger: '2.0'
+
+# This is your document metadata
+info:
+  version: "0.0.2"
+  title: TFG Trending Series v0
+  description: >-
+    The API is accessible via http://localhost:9000/api and provides the
+    following `REST` endpoints in `JSON` format.
+
+
+
+    How to use this API documentation
+
+    ----------------
+
+
+
+    You may browse the API routes freely without any authentication.
+
+
+    You will be able to use all the routes to send requests to the API and get
+    a response.
+
+
+
+    Versioning
+
+    ----------------
+
+
+
+    This documentation automatically uses the version seen at the top and
+    bottom of the page.
+
+
+
+    About this project
+
+    ----------------
+
+
+
+    This [API](https://github.com/DarkHollow/tfg-series-playAPI) and API documentation is part of a `TFG (Final Degree Project)`
+    of Software Engineering by [Roberto Cánovas ![Github](images/github-logo.png)](https://github.com/DarkHollow/) at
+    the University of Alicante (Spain). You can contact me at [Github](https://github.com/DarkHollow/), [e-mail](mailto: rcanovas.corp@gmail.com) or [Twitter](https://twitter.com/RobCanovas).
+
+    ### Status: work in progress
+
+
+basePath: /api
+tags:
+  - name: root
+    description: Status
+  - name: Search
+    description: Search for series
+  - name: Series
+    description: Information about a specific series
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /:
+    get:
+      tags:
+        - root
+      description: >-
+        Returns the status of the API and a link to the documentation
+      responses:
+        '200':
+          description: JSON response with status and doc link keys
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: status of the API
+              API_doc:
+                type: string
+                description: link to the documentation
+  /search/series/{name}:
+    get:
+      tags:
+        - Search
+      description: >-
+        Allows the user to search for series based on its name (can be partially)
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Name of the series to search for
+          type: string
+      responses:
+        '200':
+          description: JSON response with an array of all results that match partially or exact
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns basic information about all series (will be deprecated)
+      responses:
+        '200':
+          description: JSON response with an array of all series
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series/{id}:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns all information about a particular series by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the series
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the series
+          schema:
+            $ref: '#/definitions/Series'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+definitions:
+  NotFound:
+    properties:
+      error:
+        type: string
+  InternalServerError:
+    properties:
+      error:
+        type: string
+  SeriesArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: series id
+        seriesName:
+          type: string
+          description: name of the series
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+  Series:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: series id
+      seriesName:
+        type: string
+        description: name of the series
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the series
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the series airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the series
+      status:
+        type: string
+        description: status of the series (continuing or ended)

--- a/public/doc/index.html
+++ b/public/doc/index.html
@@ -37,7 +37,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "api-doc-versions/v0.0.1.yaml";
+        url = "api-doc-versions/v0.0.2.yaml";
       }
 
       hljs.configure({
@@ -91,7 +91,7 @@
 <body class="swagger-section">
 <div id='header'>
   <div class="swagger-ui-wrap">
-    <a id="logo" href="http://localhost:9000/api/doc/"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.0.1)</span></a>
+    <a id="logo" href="http://localhost:9000/api/doc/"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.0.2)</span></a>
     <!--<form id='api_selector'>
       <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
       <div id='auth_container'></div>

--- a/test/dao/SerieModelDAOTest.java
+++ b/test/dao/SerieModelDAOTest.java
@@ -64,7 +64,8 @@ public class SerieModelDAOTest {
   @Test
   public void testSerieDAOCreate() {
     Serie serie1 = new Serie(3, "Stranger Things", new Date(), "Descripción",
-      "banner.jpg", "Network", Serie.Status.Continuing);
+      "banner.jpg", "poster.jpg", "fanart.jpg", "Network", 45, null, "TV-14",
+      Serie.Status.Continuing);
 
     Serie serie2 = jpa.withTransaction(() -> {
       return SerieDAO.create(serie1);
@@ -76,14 +77,17 @@ public class SerieModelDAOTest {
     assertEquals(serie1.firstAired, serie2.firstAired);
     assertEquals(serie1.overview, serie2.overview);
     assertEquals(serie1.banner, serie2.banner);
+    assertEquals(serie1.poster, serie2.poster);
+    assertEquals(serie1.fanart, serie2.fanart);
     assertEquals(serie1.network, serie2.network);
+    assertEquals(serie1.runtime, serie2.runtime);
+    assertEquals(serie1.rating, serie2.rating);
     assertEquals(serie1.status, serie2.status);
   }
 
   // testeamos buscar por id -> found
   @Test
   public void testSerieDAOFind() {
-
     Serie serie = jpa.withTransaction(() -> {
       return SerieDAO.find(1);
     });

--- a/test/dao/SerieModelDAOTest.java
+++ b/test/dao/SerieModelDAOTest.java
@@ -65,7 +65,7 @@ public class SerieModelDAOTest {
   public void testSerieDAOCreate() {
     Serie serie1 = new Serie(3, "Stranger Things", new Date(), "Descripción",
       "banner.jpg", "poster.jpg", "fanart.jpg", "Network", 45, null, "TV-14",
-      Serie.Status.Continuing);
+      Serie.Status.Continuing, "Guionista", "Actor 1, Actor2", (float)9.0, "url_trailer");
 
     Serie serie2 = jpa.withTransaction(() -> {
       return SerieDAO.create(serie1);
@@ -83,6 +83,10 @@ public class SerieModelDAOTest {
     assertEquals(serie1.runtime, serie2.runtime);
     assertEquals(serie1.rating, serie2.rating);
     assertEquals(serie1.status, serie2.status);
+    assertEquals(serie1.writer, serie2.writer);
+    assertEquals(serie1.actors, serie2.actors);
+    assertEquals(serie1.imdbRating, serie2.imdbRating);
+    assertEquals(serie1.trailer, serie2.trailer);
   }
 
   // testeamos buscar por id -> found

--- a/test/resources/series_dataset.xml
+++ b/test/resources/series_dataset.xml
@@ -17,7 +17,9 @@
               fatigas."
     banner="graphical/78804-g44.jpg" poster="posterDoctor.jpg"
     fanart="fanartDoctor.jpg" network="BBC One" runtime="45" rating="TV-14"
-    status="Continuing" />
+    status="Continuing" writer="Sydney Newman"
+    actors="Matt Smith, David Tennant, Peter Capaldi, Jenna Coleman"
+    imdbRating="8.8" trailer="https://www.youtube.com/watch?v=kTTbfCMCQd8" />
 
   <Serie id="2" idTVDB="81189" seriesName="Breaking Bad"
     firstAired="2008-01-20"
@@ -31,5 +33,8 @@
               asegurar el bienestar económico de su familia cuando el ya no
               esté."
     banner="graphical/81189-g21.jpg"  poster="posterBreakingBad.jpg"
-    fanart="fanartBreakingBad.jpg" network="AMC" status="Ended" />
+    fanart="fanartBreakingBad.jpg" network="AMC" runtime="49" rating="TV-14"
+    status="Ended" writer="Vince Gilligan"
+    actors="ryan Cranston, Anna Gunn, Aaron Paul, Dean Norris"
+    imdbRating="9.5" trailer="https://www.youtube.com/watch?v=vISJoTGIgDI" />
 </dataset>

--- a/test/resources/series_dataset.xml
+++ b/test/resources/series_dataset.xml
@@ -15,7 +15,9 @@
               arrastrada por su curiosidad y su pasión por el riesgo, abandona
               a su madre y a su novio para convertirse en su compañera de
               fatigas."
-    banner="graphical/78804-g44.jpg" network="BBC One" status="Continuing" />
+    banner="graphical/78804-g44.jpg" poster="posterDoctor.jpg"
+    fanart="fanartDoctor.jpg" network="BBC One" runtime="45" rating="TV-14"
+    status="Continuing" />
 
   <Serie id="2" idTVDB="81189" seriesName="Breaking Bad"
     firstAired="2008-01-20"
@@ -28,5 +30,6 @@
               metanfetamina con su antiguo estudiante Jesse Pinkman para así
               asegurar el bienestar económico de su familia cuando el ya no
               esté."
-    banner="graphical/81189-g21.jpg" network="AMC" status="Ended" />
+    banner="graphical/81189-g21.jpg"  poster="posterBreakingBad.jpg"
+    fanart="fanartBreakingBad.jpg" network="AMC" status="Ended" />
 </dataset>

--- a/test/service/SerieServiceTest.java
+++ b/test/service/SerieServiceTest.java
@@ -66,7 +66,7 @@ public class SerieServiceTest {
   public void testSerieServiceCreate() {
     Serie serie1 = new Serie(3, "Stranger Things", new Date(), "Descripción",
       "banner.jpg", "poster.jpg", "fanart.jpg", "Network", 45, null, "TV-14",
-      Serie.Status.Continuing);
+      Serie.Status.Continuing, "Guionista", "Actor 1, Actor2", (float)9.0, "url_trailer");
 
     Serie serie2 = jpa.withTransaction(() -> {
       return SerieService.create(serie1);

--- a/test/service/SerieServiceTest.java
+++ b/test/service/SerieServiceTest.java
@@ -65,7 +65,8 @@ public class SerieServiceTest {
   @Test
   public void testSerieServiceCreate() {
     Serie serie1 = new Serie(3, "Stranger Things", new Date(), "Descripción",
-      "banner.jpg", "Network", Serie.Status.Continuing);
+      "banner.jpg", "poster.jpg", "fanart.jpg", "Network", 45, null, "TV-14",
+      Serie.Status.Continuing);
 
     Serie serie2 = jpa.withTransaction(() -> {
       return SerieService.create(serie1);


### PR DESCRIPTION
Deberemos ampliar los datos a almacenar para cada serie, para que al pedir una serie en concreto nos de toda la información.

También deberemos modificar la consulta de la información devuelta en las búsquedas de las series, para que de sólo información relevante que sirva para las búsquedas y no toda la información como en el caso anterior de pedir sólo una serie.

JSON View
---
Con esto haremos lo anteriormente dicho, devolviendo sólo los datos necesarios en cada momento creando vistas que filtren los datos.
[Jackson JSON Views](http://wiki.fasterxml.com/JacksonJsonViews)
[Baeldung - Jackson JSON Views](http://www.baeldung.com/jackson-json-view-annotation)

Más campos
---
Gracias a la [OMDb API](https://www.omdbapi.com/), podemos obtener más información valiosa para nuestra API y cliente, por lo que hemos decidido añadir unos cuantos campos más, en principio:

- Guionistas
- imdbRating
- Otros probables campos de la API (futuro)