### PR TITLE
Buscar: query de < 3 caracteres Bad request

### DIFF
--- a/docs/api-doc-versions/v0.0.2-not-try.yaml
+++ b/docs/api-doc-versions/v0.0.2-not-try.yaml
@@ -103,6 +103,10 @@ paths:
           description: JSON response with an array of all results that match partially or exact
           schema:
             $ref: '#/definitions/SeriesArray'
+        '400':
+          description: JSON response with 400 Bad request error (less than 3 characters searched or empty query)
+          schema:
+            $ref: '#/definitions/BadRequest'
         '404':
           description: JSON response with 404 Not Found error
           schema:
@@ -156,6 +160,10 @@ paths:
           schema:
             $ref: '#/definitions/InternalServerError'
 definitions:
+  BadRequest:
+    properties:
+      error:
+        type: string
   NotFound:
     properties:
       error:

--- a/public/doc/api-doc-versions/v0.0.2.yaml
+++ b/public/doc/api-doc-versions/v0.0.2.yaml
@@ -101,6 +101,10 @@ paths:
           description: JSON response with an array of all results that match partially or exact
           schema:
             $ref: '#/definitions/SeriesArray'
+        '400':
+          description: JSON response with 400 Bad request error (less than 3 characters searched or empty query)
+          schema:
+            $ref: '#/definitions/BadRequest'
         '404':
           description: JSON response with 404 Not Found error
           schema:
@@ -154,6 +158,10 @@ paths:
           schema:
             $ref: '#/definitions/InternalServerError'
 definitions:
+  BadRequest:
+    properties:
+      error:
+        type: string
   NotFound:
     properties:
       error:


### PR DESCRIPTION
Si se realiza una búsqueda de menos de 3 caracteres o una búsqueda vacía, la API debe devolver error Bad request.