### PR TITLE
t2.4 TVDB: buscar en TVDB y devolver resultados

### DIFF
--- a/app/controllers/RootController.java
+++ b/app/controllers/RootController.java
@@ -1,9 +1,9 @@
 package controllers;
 
-import play.mvc.*;
-import play.libs.Json;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import play.libs.Json;
+import play.mvc.Controller;
+import play.mvc.Result;
 
 public class RootController extends Controller {
 

--- a/app/controllers/TvdbController.java
+++ b/app/controllers/TvdbController.java
@@ -1,0 +1,55 @@
+package controllers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+import json.SerieViews;
+import models.Serie;
+import models.service.TvdbService;
+import play.db.jpa.Transactional;
+import play.libs.Json;
+import play.mvc.Controller;
+import play.mvc.Result;
+
+import java.util.List;
+
+public class TvdbController extends Controller {
+  @Inject
+  private TvdbService tvdbService;
+
+  // buscar series en TVDB y marcar las locales
+  // devolver la busqueda de series LIKE
+  @Transactional(readOnly = true)
+  public Result searchSeriesTVDBbyName(String query) {
+    if (query.length() >= 3) {
+      List<Serie> series = tvdbService.findOnTVDBby("name", query);
+
+      // si la lista está vacía, not found
+      if (series.isEmpty()) {
+        ObjectNode result = Json.newObject();
+        result.put("error", "Not found");
+        return notFound(result);
+      }
+
+      // si la lista no está vacía, devolvemos datos
+      try {
+        JsonNode jsonNode = Json.parse(new ObjectMapper()
+                                    .writerWithView(SerieViews.SearchTVDB.class)
+                                    .writeValueAsString(series));
+        return ok(jsonNode);
+
+      } catch (Exception ex) {
+        // si hubiese un error, devolver error interno
+        ObjectNode result = Json.newObject();
+        result.put("error", "It can't be processed");
+        return internalServerError(result);
+      }
+    } else {
+      ObjectNode result = Json.newObject();
+      result.put("error", "Bad request");
+      return badRequest(result);
+    }
+  }
+
+}

--- a/app/controllers/TvdbController.java
+++ b/app/controllers/TvdbController.java
@@ -15,8 +15,13 @@ import play.mvc.Result;
 import java.util.List;
 
 public class TvdbController extends Controller {
+
+  private final TvdbService tvdbService;
+
   @Inject
-  private TvdbService tvdbService;
+  public TvdbController(TvdbService tvdbService) {
+    this.tvdbService = tvdbService;
+  }
 
   // buscar series en TVDB y marcar las locales
   // devolver la busqueda de series LIKE

--- a/app/json/SerieViews.java
+++ b/app/json/SerieViews.java
@@ -2,6 +2,7 @@ package json;
 
 public class SerieViews {
   public static class SearchSerie {}
+  public static class SearchTVDB extends SearchSerie {}
   public static class FullSerie extends SearchSerie {}
   public static class InternalFullSerie extends FullSerie {}
 }

--- a/app/models/Serie.java
+++ b/app/models/Serie.java
@@ -76,6 +76,10 @@ public class Serie {
   @JsonView(SerieViews.FullSerie.class)
   public String trailer;
 
+  @Transient
+  @JsonView(SerieViews.SearchTVDB.class)
+  public Boolean local;
+
   // constructor vacio
   public Serie() {}
 
@@ -102,6 +106,7 @@ public class Serie {
     this.actors = actors;
     this.imdbRating = imdbRating;
     this.trailer = trailer;
+    local = false;
   }
 
   // contructor copia
@@ -122,6 +127,7 @@ public class Serie {
     this.actors = serie.actors;
     this.imdbRating = serie.imdbRating;
     this.trailer = serie.trailer;
+    this.local = false;
   }
 
   // solo informacion importante

--- a/app/models/service/TvdbService.java
+++ b/app/models/service/TvdbService.java
@@ -1,0 +1,64 @@
+package models.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.inject.Inject;
+import models.Serie;
+import play.libs.ws.WSClient;
+import play.libs.ws.WSResponse;
+import utils.TVDB;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+public class TvdbService {
+    @Inject
+    private WSClient ws;
+
+  // buscar en tvdb y en local, marcar las que coinciden
+  // buscar por campo exacto o LIKE
+  public List<Serie> findOnTVDBby(String field, String value) {
+    // buscamos la serie en tvdb
+    JsonNode respuesta = null;
+    List<Serie> series = new ArrayList<>();
+
+    try {
+      CompletionStage<JsonNode> response = ws.url("https://api.thetvdb.com/search/series")
+                                                .setHeader("Authorization", "Bearer " + TVDB.getToken())
+                                                .setHeader("Accept-Language", "es")
+                                                .setQueryParameter(field, value)
+                                                .get()
+                                                .thenApply(WSResponse::asJson);
+
+      respuesta = response.toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+      System.out.println(respuesta);
+    } catch (Exception ex) {
+      System.out.println(ex.getMessage());
+    }
+
+    // recorremos series encontradas en TVDB
+    if (respuesta != null && respuesta.has("data")) {
+      for (JsonNode jsonSerie : respuesta.withArray("data")) {
+        // obtenemos datos de la serie
+        Serie nuevaSerie = new Serie();
+        nuevaSerie.idTVDB = Integer.parseInt(jsonSerie.get("id").asText());
+        nuevaSerie.seriesName = jsonSerie.get("seriesName").asText();
+        nuevaSerie.banner = jsonSerie.get("banner").asText();
+
+        // buscamos en local para indicar si la tenemos o no
+        Serie serieLocal = SerieService.findByIdTvdb(nuevaSerie.idTVDB);
+        if (serieLocal != null) {
+          nuevaSerie.local = true;
+        }
+
+        // finalmente la añadimos a la lista
+        series.add(nuevaSerie);
+      }
+    }
+
+    return series;
+  }
+
+}

--- a/conf/routes
+++ b/conf/routes
@@ -36,3 +36,7 @@ GET     /api/series/:id             controllers.SerieController.serieById(id: In
 # series search by LIKE
 GET     /api/search/series/:q/      controllers.SerieController.searchSeriesNameLike(q: String)
 GET     /api/search/series/:q       controllers.SerieController.searchSeriesNameLike(q: String)
+
+# series search on TVDB by name
+GET     /api/search/TVDB/:q/        controllers.TvdbController.searchSeriesTVDBbyName(q: String)
+GET     /api/search/TVDB/:q         controllers.TvdbController.searchSeriesTVDBbyName(q: String)

--- a/docs/api-doc-versions/v0.1.1-not-try.yaml
+++ b/docs/api-doc-versions/v0.1.1-not-try.yaml
@@ -1,0 +1,290 @@
+# Example YAML to get you started quickly.
+# Be aware that YAML has indentation based scoping.
+# Code completion support is available so start typing for available options.
+swagger: '2.0'
+
+# This is your document metadata
+info:
+  version: "0.1.1"
+  title: TFG Trending Series v0 `Offline`
+  description: >-
+    The API is accessible via https://darkhollow.github.com/tfg-series-playAPI/
+    and provides the following `REST` endpoints in `JSON` format.
+
+
+
+    How to use this API documentation
+
+    ----------------
+
+
+
+    You may browse the API routes freely without any authentication.
+
+
+    You will **NOT** be able to use the routes to send requests to the API and
+    get a response because this is a `Offline Documentation` for `Github Pages`.
+
+    Because of that, the button `Try it out` is disabled in all the routes.
+
+
+
+    Versioning
+
+    ----------------
+
+
+
+    This documentation automatically uses the version seen at the top and
+    bottom of the page.
+
+
+
+    About this project
+
+    ----------------
+
+
+
+    This [API](https://github.com/DarkHollow/tfg-series-playAPI) and API documentation is part of a `TFG (Final Degree Project)`
+    of Software Engineering by [Roberto Cánovas ![Github](images/github-logo.png)](https://github.com/DarkHollow/) at
+    the University of Alicante (Spain). You can contact me at [Github](https://github.com/DarkHollow/), [e-mail](mailto: rcanovas.corp@gmail.com) or [Twitter](https://twitter.com/RobCanovas).
+
+    ### Status: work in progress
+
+
+basePath: /api
+tags:
+  - name: root
+    description: Status
+  - name: Search
+    description: Search for series
+  - name: Series
+    description: Information about a specific series
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /:
+    get:
+      tags:
+        - root
+      description: >-
+        Returns the status of the API and a link to the documentation
+      responses:
+        '200':
+          description: JSON response with status and doc link keys
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: status of the API
+              API_doc:
+                type: string
+                description: link to the documentation
+  /search/series/{name}:
+    get:
+      tags:
+        - Search
+      description: >-
+        Allows the user to search for series based on its name (can be partially)
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Name of the series to search for
+          type: string
+      responses:
+        '200':
+          description: JSON response with an array of all results that match partially or exact
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '400':
+          description: JSON response with 400 Bad request error (less than 3 characters searched or empty query)
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /search/TVDB/{name}:
+    get:
+      tags:
+        - Search
+      description: >-
+        Allows the user to search for series based on its name on TVDB and match them with series in our bbdd
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Name of the series to search for
+          type: string
+      responses:
+        '200':
+          description: JSON response with an array of all results that match partially or exact
+          schema:
+            $ref: '#/definitions/TvdbSeriesArray'
+        '400':
+          description: JSON response with 400 Bad request error (less than 3 characters searched or empty query)
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns basic information about all series (will be deprecated)
+      responses:
+        '200':
+          description: JSON response with an array of all series
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series/{id}:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns all information about a particular series by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the series
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the series
+          schema:
+            $ref: '#/definitions/Series'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+definitions:
+  BadRequest:
+    properties:
+      error:
+        type: string
+  NotFound:
+    properties:
+      error:
+        type: string
+  InternalServerError:
+    properties:
+      error:
+        type: string
+  SeriesArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: series id
+        seriesName:
+          type: string
+          description: name of the series
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+  TvdbSeriesArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: series id
+        seriesName:
+          type: string
+          description: name of the series
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+        local:
+          type: bool
+          description: true if the series is in our bbdd
+  Series:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: series id
+      seriesName:
+        type: string
+        description: name of the series
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the series
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the series airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the series
+      status:
+        type: string
+        description: status of the series (continuing or ended)
+      writer:
+        type: string
+        description: writer or writers of the series
+      actors:
+        type: string
+        description: principal actors of the series
+      imdbRating:
+        type: float
+        description: average rating on imdb of the series
+      trailer:
+        type: string
+        description: YouTube video code of the trailer

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "api-doc-versions/v0.1.0-not-try.yaml";
+        url = "api-doc-versions/v0.1.1-not-try.yaml";
       }
 
       hljs.configure({
@@ -91,7 +91,7 @@
 <body class="swagger-section">
 <div id='header'>
   <div class="swagger-ui-wrap">
-    <a id="logo" href="tfg-series-playAPI"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.1.0)</span></a>
+    <a id="logo" href="tfg-series-playAPI"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.1.1)</span></a>
     <!--<form id='api_selector'>
       <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
       <div id='auth_container'></div>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // The Play plugin
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.12")
 
 // Web plugins
 addSbtPlugin("com.typesafe.sbt" % "sbt-coffeescript" % "1.0.0")

--- a/public/doc/api-doc-versions/v0.1.1.yaml
+++ b/public/doc/api-doc-versions/v0.1.1.yaml
@@ -1,0 +1,288 @@
+# Example YAML to get you started quickly.
+# Be aware that YAML has indentation based scoping.
+# Code completion support is available so start typing for available options.
+swagger: '2.0'
+
+# This is your document metadata
+info:
+  version: "0.1.1"
+  title: TFG Trending Series v0
+  description: >-
+    The API is accessible via http://localhost:9000/api and provides the
+    following `REST` endpoints in `JSON` format.
+
+
+
+    How to use this API documentation
+
+    ----------------
+
+
+
+    You may browse the API routes freely without any authentication.
+
+
+    You will be able to use all the routes to send requests to the API and get
+    a response.
+
+
+
+    Versioning
+
+    ----------------
+
+
+
+    This documentation automatically uses the version seen at the top and
+    bottom of the page.
+
+
+
+    About this project
+
+    ----------------
+
+
+
+    This [API](https://github.com/DarkHollow/tfg-series-playAPI) and API documentation is part of a `TFG (Final Degree Project)`
+    of Software Engineering by [Roberto Cánovas ![Github](images/github-logo.png)](https://github.com/DarkHollow/) at
+    the University of Alicante (Spain). You can contact me at [Github](https://github.com/DarkHollow/), [e-mail](mailto: rcanovas.corp@gmail.com) or [Twitter](https://twitter.com/RobCanovas).
+
+    ### Status: work in progress
+
+
+basePath: /api
+tags:
+  - name: root
+    description: Status
+  - name: Search
+    description: Search for series
+  - name: Series
+    description: Information about a specific series
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /:
+    get:
+      tags:
+        - root
+      description: >-
+        Returns the status of the API and a link to the documentation
+      responses:
+        '200':
+          description: JSON response with status and doc link keys
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: status of the API
+              API_doc:
+                type: string
+                description: link to the documentation
+  /search/series/{name}:
+    get:
+      tags:
+        - Search
+      description: >-
+        Allows the user to search for series based on its name (can be partially)
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Name of the series to search for
+          type: string
+      responses:
+        '200':
+          description: JSON response with an array of all results that match partially or exact
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '400':
+          description: JSON response with 400 Bad request error (less than 3 characters searched or empty query)
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /search/TVDB/{name}:
+    get:
+      tags:
+        - Search
+      description: >-
+        Allows the user to search for series based on its name on TVDB and match them with series in our bbdd
+      parameters:
+        - name: name
+          in: path
+          required: true
+          description: Name of the series to search for
+          type: string
+      responses:
+        '200':
+          description: JSON response with an array of all results that match partially or exact
+          schema:
+            $ref: '#/definitions/TvdbSeriesArray'
+        '400':
+          description: JSON response with 400 Bad request error (less than 3 characters searched or empty query)
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns basic information about all series (will be deprecated)
+      responses:
+        '200':
+          description: JSON response with an array of all series
+          schema:
+            $ref: '#/definitions/SeriesArray'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /series/{id}:
+    get:
+      tags:
+        - Series
+      description: >-
+        Returns all information about a particular series by id
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the series
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the series
+          schema:
+            $ref: '#/definitions/Series'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+definitions:
+  BadRequest:
+    properties:
+      error:
+        type: string
+  NotFound:
+    properties:
+      error:
+        type: string
+  InternalServerError:
+    properties:
+      error:
+        type: string
+  SeriesArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: series id
+        seriesName:
+          type: string
+          description: name of the series
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+  TvdbSeriesArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: series id
+        seriesName:
+          type: string
+          description: name of the series
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+        local:
+          type: bool
+          description: true if the series is in our bbdd
+  Series:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: series id
+      seriesName:
+        type: string
+        description: name of the series
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the series
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the series airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the series
+      status:
+        type: string
+        description: status of the series (continuing or ended)
+      writer:
+        type: string
+        description: writer or writers of the series
+      actors:
+        type: string
+        description: principal actors of the series
+      imdbRating:
+        type: float
+        description: average rating on imdb of the series
+      trailer:
+        type: string
+        description: YouTube video code of the trailer

--- a/public/doc/index.html
+++ b/public/doc/index.html
@@ -37,7 +37,7 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "api-doc-versions/v0.1.0.yaml";
+        url = "api-doc-versions/v0.1.1.yaml";
       }
 
       hljs.configure({
@@ -91,7 +91,7 @@
 <body class="swagger-section">
 <div id='header'>
   <div class="swagger-ui-wrap">
-    <a id="logo" href="http://localhost:9000/api/doc/"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.1.0)</span></a>
+    <a id="logo" href="http://localhost:9000/api/doc/"><img class="logo__img" alt="swagger" height="30" width="30" src="images/logo_small.png" /><span class="logo__title">TFG Trending Series API (v0.1.1)</span></a>
     <!--<form id='api_selector'>
       <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/></div>
       <div id='auth_container'></div>

--- a/test/service/TvdbServiceTest.java
+++ b/test/service/TvdbServiceTest.java
@@ -1,0 +1,83 @@
+package service;
+
+import models.Serie;
+import models.service.TvdbService;
+import org.dbunit.JndiDatabaseTester;
+import org.dbunit.dataset.IDataSet;
+import org.dbunit.dataset.xml.FlatXmlDataSetBuilder;
+import org.dbunit.operation.DatabaseOperation;
+import org.junit.*;
+import play.api.Play;
+import play.db.Database;
+import play.db.Databases;
+import play.db.jpa.JPA;
+import play.db.jpa.JPAApi;
+
+import java.io.FileInputStream;
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static play.test.Helpers.*;
+
+public class TvdbServiceTest {
+  private static Database db;
+  private static JPAApi jpa;
+  private JndiDatabaseTester databaseTester;
+
+  @BeforeClass
+  static public void initDatabase() {
+    // conectamos con la base de datos de test
+    db = Databases.inMemoryWith("jndiName", "DefaultDS");
+    db.getConnection();
+    // activamos modo MySQL
+    db.withConnection(connection -> {
+      connection.createStatement().execute("SET MODE MySQL;");
+    });
+    jpa = JPA.createFor("memoryPersistenceUnit");
+  }
+
+  @Before
+  public void initData() throws Exception {
+    databaseTester = new JndiDatabaseTester("DefaultDS");
+    IDataSet initialDataSet = new FlatXmlDataSetBuilder().build(new
+      FileInputStream("test/resources/series_dataset.xml"));
+    databaseTester.setDataSet(initialDataSet);
+
+    // Set up - CLEAN_INSERT: primero delete all y despues insert
+    databaseTester.setSetUpOperation(DatabaseOperation.CLEAN_INSERT);
+    // On tear down - DELETE_ALL: primero borrar contenido del dataset
+    databaseTester.setTearDownOperation(DatabaseOperation.DELETE_ALL);
+
+    databaseTester.onSetup();
+  }
+
+  @After
+  public void clearData() throws Exception {
+    databaseTester.onTearDown();
+  }
+
+  // al final limpiamos la base de datos y la cerramos
+  @AfterClass
+  static public void shutdownDatabase() {
+    jpa.shutdown();
+    db.shutdown();
+  }
+
+  // testeamos buscar en TVDB por nombre (fakeapp para obtener login tvdb)
+  @Test
+  public void testTvdbServiceFindByName() {
+
+    running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, browser -> {
+      browser.goTo("http://localhost:3333");
+      // injector
+      TvdbService tvdbService = Play.current().injector().instanceOf(TvdbService.class);
+
+      List<Serie> series = jpa.withTransaction(() -> tvdbService.findOnTVDBby("name", "stranger"));
+
+      assertNotNull(series);
+      assertFalse(series.isEmpty());
+    });
+  }
+
+}

--- a/test/service/TvdbServiceTest.java
+++ b/test/service/TvdbServiceTest.java
@@ -70,7 +70,7 @@ public class TvdbServiceTest {
 
     running(testServer(3333, fakeApplication(inMemoryDatabase())), HTMLUNIT, browser -> {
       browser.goTo("http://localhost:3333");
-      // injector
+      // injector explícito, no podemos usar mocks aquí
       TvdbService tvdbService = Play.current().injector().instanceOf(TvdbService.class);
 
       List<Serie> series = jpa.withTransaction(() -> tvdbService.findOnTVDBby("name", "stranger"));


### PR DESCRIPTION
Búsqueda de series en TVDB para poder realizar la petición de una serie que no tengamos en nuestra base de datos.

- Petición: `GET` para buscar en TVDB
- Respuesta: datos de las series encontradas en TVDB

En la petición, de momento sólo se aceptará el campo `nombre de la serie`
En la respuesta, se indicará si las tenemos en nuestra base de datos o no en el campo `local`

**Respuesta**

```json
[
  {
    "id": 1,
    "seriesName": "Nombre serie",
    "firstAired": "2017-02-13",
    "banner": "url/to/banner.jpg",
    "local": true
  }
]
```

#### Cambios necesarios

- Serie: nuevo campo `@Transient local`. Este campo nos servirá para marcar si lo tenemos en nuestra base de datos o no, al ser `transient`, no se almacenará en la base de datos ya que es innecesario

- Nuevo Controller: TvdbController
 - buscar series en TVDB por nombre
- Nuevo Service: TvdbService
 - buscar series en TVDB por nombre, aquí se hará todo el procesamiento y el match con nuestra base de datos
- Nueva ruta: routes -> search -> TVDB -> por nombre
- Nueva JsonView para series que contenga el campo transient local