### PR TITLE
Fix: buscar en TVDB debe devolver id y idTVDB

### DIFF
--- a/app/controllers/TvShowRequestController.java
+++ b/app/controllers/TvShowRequestController.java
@@ -54,7 +54,9 @@ public class TvShowRequestController extends Controller {
 
       // si la lista no está vacía, comprobamos series en local
       for (TvShow tvShow : tvShows) {
-        if (tvShowService.findByTvdbId(tvShow.tvdbId) != null) {
+        TvShow localTvShow = tvShowService.findByTvdbId(tvShow.tvdbId);
+        if (localTvShow != null) {
+          tvShow.id = localTvShow.id;
           tvShow.local = true;
         }
       }

--- a/app/json/TvShowViews.java
+++ b/app/json/TvShowViews.java
@@ -2,7 +2,8 @@ package json;
 
 public class TvShowViews {
   public static class SearchTvShow {}
-  public static class SearchTVDB extends SearchTvShow {}
-  public static class FullTvShow extends SearchTvShow {}
+  public static class SearchTvShowTvdbId extends SearchTvShow {}
+  public static class SearchTVDB extends SearchTvShowTvdbId {}
+  public static class FullTvShow extends SearchTvShowTvdbId {}
   public static class InternalFullTvShow extends FullTvShow {}
 }

--- a/app/models/TvShow.java
+++ b/app/models/TvShow.java
@@ -19,7 +19,7 @@ public class TvShow {
   @JsonView(TvShowViews.SearchTvShow.class)
   public Integer id;
 
-  @JsonView(TvShowViews.InternalFullTvShow.class)
+  @JsonView(TvShowViews.SearchTvShowTvdbId.class)
   public Integer tvdbId;
 
   @Column(length = 100)


### PR DESCRIPTION
Las series encontradas en TVDB, si se encuentran en local se debe devolver la id y además se debe devolver siempre la id de TVDB.

La solución de la id local es una simple asignación a la hora de comprobar si está en local.
Para la id de TVDB se ha modificado la estructura de vistas JSON.