### PR TITLE
Restringir funciones y rutas por roles

### DIFF
--- a/app/controllers/TvShowController.java
+++ b/app/controllers/TvShowController.java
@@ -11,6 +11,9 @@ import play.db.jpa.Transactional;
 import play.libs.Json;
 import play.mvc.Controller;
 import play.mvc.Result;
+import play.mvc.Security;
+import utils.Security.Administrator;
+import utils.Security.Roles;
 
 import java.util.List;
 
@@ -27,6 +30,7 @@ public class TvShowController extends Controller {
   // JSON View TvShowView.SearchTvShow: vista que solo incluye los campos
   // relevante de una búsqueda
   @Transactional(readOnly = true)
+  @Security.Authenticated(Administrator.class)
   public Result all() {
     List<TvShow> tvShows = tvShowService.all();
 
@@ -54,6 +58,7 @@ public class TvShowController extends Controller {
 
   // devolver un TV Show por id
   @Transactional(readOnly = true)
+  @Security.Authenticated(Roles.class)
   public Result tvShowById(Integer id) {
     TvShow tvShow = tvShowService.find(id);
     if (tvShow == null) {
@@ -79,6 +84,7 @@ public class TvShowController extends Controller {
 
   // devolver la busqueda de TV Shows LIKE
   @Transactional(readOnly = true)
+  @Security.Authenticated(Roles.class)
   public Result searchTvShowNameLike(String query) {
     if (query.length() >= 3) {
       List<TvShow> tvShows = tvShowService.findBy("name", query, false);

--- a/app/controllers/TvShowRequestController.java
+++ b/app/controllers/TvShowRequestController.java
@@ -21,6 +21,7 @@ import play.mvc.Controller;
 import play.mvc.Result;
 import play.mvc.Security;
 import utils.Security.Administrator;
+import utils.Security.User;
 
 import java.util.List;
 
@@ -46,6 +47,7 @@ public class TvShowRequestController extends Controller {
   // buscar TV Show en TVDB y marcar las locales
   // devolver la busqueda de TV Show LIKE
   @Transactional(readOnly = true)
+  @Security.Authenticated(User.class)
   public Result searchTvShowTVDBbyName(String query) {
     if (query.length() >= 3) {
       List<TvShow> tvShows = tvdbService.findOnTVDBby("name", query);
@@ -98,6 +100,7 @@ public class TvShowRequestController extends Controller {
   // Peticion POST TvShow nuevo
   // realizar la petición del TV Show
   @Transactional
+  @Security.Authenticated(User.class)
   public Result requestTvShow() {
     ObjectNode result = Json.newObject();
     Integer tvdbId, userId;

--- a/app/controllers/TvdbController.java
+++ b/app/controllers/TvdbController.java
@@ -11,6 +11,8 @@ import play.db.jpa.Transactional;
 import play.libs.Json;
 import play.mvc.Controller;
 import play.mvc.Result;
+import play.mvc.Security;
+import utils.Security.Administrator;
 
 public class TvdbController extends Controller {
 
@@ -23,6 +25,7 @@ public class TvdbController extends Controller {
 
   // buscar TV Show en TVDB por id
   @Transactional(readOnly = true)
+  @Security.Authenticated(Administrator.class)
   public Result tvShowById(Integer tvdbId) {
 
     TvShow tvShow = tvdbService.findOnTvdbByTvdbId(tvdbId);

--- a/app/utils/Security/Roles.java
+++ b/app/utils/Security/Roles.java
@@ -45,7 +45,6 @@ public class Roles extends Security.Authenticator {
         DecodedJWT jwt = verifier.verify(token);
         Claim emailClaim = jwt.getClaim("email");
         Claim rolClaim = jwt.getClaim("rol");
-
         // comprobamos si los claims no son null
         if (!emailClaim.isNull() && !rolClaim.isNull()) {
             // comprobamos que el usuario exista
@@ -69,7 +68,7 @@ public class Roles extends Security.Authenticator {
         return null;
       }
     }
-
+    Logger.warn("jwt roles - se ha deducido que el usuario no tiene autorización?");
     return null;
   }
 

--- a/app/utils/Security/User.java
+++ b/app/utils/Security/User.java
@@ -48,27 +48,27 @@ public class User extends Roles {
               if (user.rol.equals(ROL)) {
                 return user.email;
               } else {
-                Logger.warn("jwt - se ha detectado token de usuario que no es usuario");
+                Logger.warn("jwt user - se ha detectado token de usuario que no es user");
                 return null;
               }
             } else {
-              Logger.warn("jwt - se ha detectado token de usuario que no existe");
+              Logger.warn("jwt user - se ha detectado token de usuario que no existe");
               return null;
             }
           } else {
-            Logger.warn("jwt - se ha detectado token con claim rol = " + rolClaim.asString());
+            Logger.warn("jwt user - se ha detectado token con claim rol = " + rolClaim.asString());
             return null;
           }
         } else {
-          Logger.warn("jwt - se ha detectado token sin claim email y/o rol");
+          Logger.warn("jwt user - se ha detectado token sin claim email y/o rol");
           return null;
         }
 
       } catch (UnsupportedEncodingException ex) {
-        Logger.error("jwt - verifier.verify(token) ha generado UnsupportedEncodingException");
+        Logger.error("jwt user - verifier.verify(token) ha generado UnsupportedEncodingException");
         return null;
       } catch (JWTVerificationException ex) {
-        Logger.debug("jwt - verifier.verify(token) ha generado JWTVerificationException");
+        Logger.debug("jwt user - verifier.verify(token) ha generado JWTVerificationException");
         return null;
       }
     }

--- a/app/views/administration/tvShowRequests.scala.html
+++ b/app/views/administration/tvShowRequests.scala.html
@@ -173,6 +173,11 @@
                     url: 'http://localhost:9000/api/tvshows/tvdb/' + @request.tvdbId,
                     type: 'GET',
                     dataType: 'json',
+                    headers: {
+                        'Accept': 'application/json',
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + window.localStorage.getItem('jwt')
+                    },
                     success: function (response) {
                         var row = '';
                         row +=

--- a/public/javascripts/pages/tvShowRequests.js
+++ b/public/javascripts/pages/tvShowRequests.js
@@ -311,6 +311,11 @@ $(document).on('click', '[data-action=get-tvShow-data]', function(e) {
     url: 'http://localhost:9000/api/tvshows/tvdb/' + tvdbId,
     type: 'GET',
     dataType: 'json',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + window.localStorage.getItem('jwt')
+    },
     success: function (response) {
       let name = response.name;
       let firstAired = response.firstAired;
@@ -333,11 +338,10 @@ $(document).on('click', '[data-action=get-tvShow-data]', function(e) {
 
   $.when.apply(null, promises).done(function() {
     $('#actions-' + requestId).html('<i class="icon-checkmark4 text-green"></i>');
-  });
-
-  $.when.apply(null, promises).error(function() {
+  }).fail(function() {
     $('#actions-' + requestId).html('<i class="icon-cross2 text-danger"></i>');
   });
+
 });
 
 $(function() {


### PR DESCRIPTION
Utilizar la etiqueta `@Security.Authenticated` para restringir todas las llamadas a funciones de controladores o controladores completos con las clases que hemos implementado de cada rol.

`Administrator.class` para las llamadas restringidas de administrador
`User.class` para las llamadas restringidas de usuario
`Roles.class` par alas llamadas restringidas de cualquier rol