### PR TITLE
Fix heroku evolutions

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: target/universal/stage/bin/tfg-api -Dhttp.port=$PORT -Dconfig.resource=prod.conf -Dplay.evolutions.db.default.autoApply=true
+web: target/universal/stage/bin/tfg-api -Dhttp.port=$PORT -Dconfig.resource=prod.conf

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: target/universal/stage/bin/tfg-api -Dhttp.port=$PORT -Dconfig.resource=prod.conf
+web: target/universal/stage/bin/tfg-api -Dhttp.port=$PORT -Dconfig.resource=prod.conf -Dplay.evolutions.db.default.autoApply=true

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -31,7 +31,7 @@
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
-      <property name="hibernate.hbm2ddl.auto" value="update"/>
+      <property name="hibernate.hbm2ddl.auto" value="validate"/>
       <property name="hibernate.show_sql" value="true"/>
     </properties>
   </persistence-unit>

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -20,7 +20,18 @@
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
-      <property name="hibernate.hbm2ddl.auto" value="update"/>
+      <property name="hibernate.hbm2ddl.auto" value="validate"/>
+      <property name="hibernate.show_sql" value="true"/>
+    </properties>
+  </persistence-unit>
+
+  <!-- Production MySQL Persistence Unit -->
+  <persistence-unit name="productionMySqlPersistenceUnit" transaction-type="RESOURCE_LOCAL">
+    <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+    <non-jta-data-source>DefaultDS</non-jta-data-source>
+    <properties>
+      <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
+      <property name="hibernate.hbm2ddl.auto" value="validate"/>
       <property name="hibernate.show_sql" value="true"/>
     </properties>
   </persistence-unit>

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -31,7 +31,7 @@
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
-      <property name="hibernate.hbm2ddl.auto" value="update"/>
+      <!--<property name="hibernate.hbm2ddl.auto" value="update"/> LO DESHABILITAMOS PARA PRODUCCION -->
       <property name="hibernate.show_sql" value="true"/>
     </properties>
   </persistence-unit>

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -31,7 +31,7 @@
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
-      <property name="hibernate.hbm2ddl.auto" value="validate"/>
+      <property name="hibernate.hbm2ddl.auto" value="update"/>
       <property name="hibernate.show_sql" value="true"/>
     </properties>
   </persistence-unit>

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -20,18 +20,18 @@
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
-      <property name="hibernate.hbm2ddl.auto" value="validate"/>
+      <property name="hibernate.hbm2ddl.auto" value="update"/>
       <property name="hibernate.show_sql" value="true"/>
     </properties>
   </persistence-unit>
 
-  <!-- Production MySQL Persistence Unit -->
+  <!-- MySQL Persistence Unit -->
   <persistence-unit name="productionMySqlPersistenceUnit" transaction-type="RESOURCE_LOCAL">
     <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
-      <property name="hibernate.hbm2ddl.auto" value="validate"/>
+      <property name="hibernate.hbm2ddl.auto" value="update"/>
       <property name="hibernate.show_sql" value="true"/>
     </properties>
   </persistence-unit>

--- a/conf/prod.conf
+++ b/conf/prod.conf
@@ -8,4 +8,4 @@ db.default.username = "b7f80627de3e40"
 db.default.password = "4cdcd3a1"
 db.default.jndiName=DefaultDS
 
-jpa.default=mySqlPersistenceUnit
+jpa.default=productionMySqlPersistenceUnit


### PR DESCRIPTION
Al parecer en nuestro entorno de producción Heroku, Hibernate sí que hace `ALTER TABLE` cuando añadimos un atributo nuevo a una entidad que ya existe, pero en debug en playframework no, así que para producción hemos deshabilitado la autogeneración del esquema por lo que habrá que en evolutions poner hasta los `CREATE TABLE`.