### PR TITLE
Extraer función repetida 'parseDate' y más

### DIFF
--- a/app/models/service/external/JsonUtils.java
+++ b/app/models/service/external/JsonUtils.java
@@ -1,0 +1,37 @@
+package models.service.external;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import play.Logger;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public class JsonUtils {
+
+  // parsear fecha
+  public Date parseDate(JsonNode jsonDate) {
+    int i = 0, tries = 100;
+    Date result = null;
+    SimpleDateFormat df = new SimpleDateFormat();
+
+    if (!jsonDate.isNull() && !jsonDate.asText().equals("")) {
+
+      while (i < tries) {
+        try {
+          df.applyPattern("yyyy-MM-dd");
+          result = df.parse(jsonDate.asText()); // fecha estreno
+          break;
+        } catch (Exception e) {
+          i++;
+          if (i != 100) {
+            Logger.info("Reintentando parsear fecha de estreno");
+          } else {
+            Logger.error("No se ha podido parsear la fecha");
+          }
+        }
+      }
+    }
+
+    return result;
+  }
+}

--- a/app/models/service/external/TmdbService.java
+++ b/app/models/service/external/TmdbService.java
@@ -3,21 +3,11 @@ package models.service.external;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import models.TvShow;
-import org.hibernate.context.TenantIdentifierMismatchException;
 import play.Logger;
 import play.libs.ws.WSClient;
 import play.libs.ws.WSResponse;
 
-import javax.imageio.ImageIO;
-import java.awt.image.BufferedImage;
 import java.io.File;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -26,15 +16,15 @@ import java.util.concurrent.TimeoutException;
 public class TmdbService {
 
   private final WSClient ws;
-  private final SimpleDateFormat df;
+  private final JsonUtils jsonUtils;
   private final TmdbConnection tmdbConnection;
 
   private static char SEPARATOR = File.separatorChar;
 
   @Inject
-  public TmdbService(WSClient ws, SimpleDateFormat df, TmdbConnection tmdbConnection) {
+  public TmdbService(WSClient ws, JsonUtils jsonUtils, TmdbConnection tmdbConnection) {
     this.ws = ws;
-    this.df = df;
+    this.jsonUtils = jsonUtils;
     this.tmdbConnection = tmdbConnection;
   }
 
@@ -104,39 +94,13 @@ public class TmdbService {
       tvShow.fanart = jsonTvShow.get("backdrop_path").asText();
       tvShow.local = false;
       JsonNode fecha = jsonTvShow.get("first_aire_date");
-      tvShow.firstAired = parseDate(fecha);
+      tvShow.firstAired = jsonUtils.parseDate(fecha);
 
     } else {
       Logger.info("TvShow no encontrada en The Movie Database API");
     }
 
     return tvShow;
-  }
-
-  // parsear fecha
-  private Date parseDate(JsonNode jsonDate) {
-    int i = 0, tries = 100;
-    Date result = null;
-
-    if (!jsonDate.isNull() && !jsonDate.asText().equals("")) {
-
-      while (i < tries) {
-        try {
-          df.applyPattern("yyyy-MM-dd");
-          result = df.parse(jsonDate.asText()); // fecha estreno
-          break;
-        } catch (Exception e) {
-          i++;
-          if (i != 100) {
-            Logger.info("Reintentando parsear fecha de estreno");
-          } else {
-            Logger.error("No se ha podido parsear la fecha");
-          }
-        }
-      }
-    }
-
-    return result;
   }
 
 }

--- a/app/views/administration/index.scala.html
+++ b/app/views/administration/index.scala.html
@@ -39,7 +39,7 @@
                                 </div>
                                 <div class="media-body">
                                     Series en el sistema
-                                    <div class="media-annotation">Series que son accesibles que habitan la base de datos</div>
+                                    <div class="media-annotation">Series que habitan la base de datos</div>
                                 </div>
                             </a>
                         </li>
@@ -93,7 +93,7 @@
                                 </div>
                                 <div class="media-body">
                                     Peticiones aceptadas
-                                    <div class="media-annotation">Peticiones que han sido aprobadas y persistidas</div>
+                                    <div class="media-annotation">Peticiones aprobadas y persistidas</div>
                                 </div>
                             </a>
                         </li>

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -31,7 +31,7 @@
     <non-jta-data-source>DefaultDS</non-jta-data-source>
     <properties>
       <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL5Dialect"/>
-      <!--<property name="hibernate.hbm2ddl.auto" value="update"/> LO DESHABILITAMOS PARA PRODUCCION -->
+      <property name="hibernate.hbm2ddl.auto" value="validate"/> <!-- probando validate en heroku -->
       <property name="hibernate.show_sql" value="true"/>
     </properties>
   </persistence-unit>

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -323,3 +323,40 @@
     text-align: center;
     padding-top: 200px;
 }
+
+/* device view */
+@media (max-width: 768px) {
+    .page-container {
+        padding: 8px;
+    }
+
+    .page-header-inverse {
+        margin-bottom: 0;
+    }
+
+    .page-title {
+        padding: 0;
+    }
+
+    .panel {
+        margin-bottom: 8px;
+    }
+
+    .panel-body {
+        padding-top: 0;
+        padding-bottom: 6px;
+    }
+
+    .menu-list {
+        margin: 0;
+    }
+
+    .menu-list li > a {
+        color: #000;
+    }
+
+    .alert {
+        margin-bottom: 8px;
+    }
+}
+

--- a/test/service/external/TmdbServiceItTest.java
+++ b/test/service/external/TmdbServiceItTest.java
@@ -1,6 +1,7 @@
 package service.external;
 
 import models.TvShow;
+import models.service.external.JsonUtils;
 import models.service.external.TmdbConnection;
 import models.service.external.TmdbService;
 import org.dbunit.JndiDatabaseTester;
@@ -32,7 +33,7 @@ public class TmdbServiceItTest {
   private static JPAApi jpa;
   private JndiDatabaseTester databaseTester;
   private static WSClient ws;
-  private static SimpleDateFormat df;
+  private static JsonUtils jsonUtils;
   private static TmdbService tmdbService;
 
   private final static int PORT = 3333;
@@ -50,7 +51,7 @@ public class TmdbServiceItTest {
 
     // inicializamos mocks y servicios
     ws = WS.newClient(PORT);
-    df = mock(SimpleDateFormat.class);
+    jsonUtils = mock(JsonUtils.class);
 
     // inicializamos base de datos de prueba
     databaseTester = new JndiDatabaseTester("DefaultDS");
@@ -79,7 +80,7 @@ public class TmdbServiceItTest {
     running(testServer(PORT, fakeApplication(inMemoryDatabase())), new HtmlUnitDriver(), browser -> {
       browser.goTo("http://localhost:" + PORT);
 
-      tmdbService = new TmdbService(ws, df, Play.current().injector().instanceOf(TmdbConnection.class));
+      tmdbService = new TmdbService(ws, jsonUtils, Play.current().injector().instanceOf(TmdbConnection.class));
 
       jpa.withTransaction(() -> {
         try {
@@ -99,7 +100,7 @@ public class TmdbServiceItTest {
     running(testServer(PORT, fakeApplication(inMemoryDatabase())), new HtmlUnitDriver(), browser -> {
       browser.goTo("http://localhost:" + PORT);
 
-      TmdbService tmdbService = new TmdbService(ws, df, Play.current().injector().instanceOf(TmdbConnection.class));
+      TmdbService tmdbService = new TmdbService(ws, jsonUtils, Play.current().injector().instanceOf(TmdbConnection.class));
 
       jpa.withTransaction(() -> {
         try {

--- a/test/service/external/TvdbServiceItTest.java
+++ b/test/service/external/TvdbServiceItTest.java
@@ -1,6 +1,7 @@
 package service.external;
 
 import models.TvShow;
+import models.service.external.JsonUtils;
 import models.service.external.TvdbConnection;
 import models.service.external.TvdbService;
 import org.dbunit.JndiDatabaseTester;
@@ -33,7 +34,7 @@ public class TvdbServiceItTest {
   private static JPAApi jpa;
   private JndiDatabaseTester databaseTester;
   private static WSClient ws;
-  private static SimpleDateFormat df;
+  private static JsonUtils jsonUtils;
 
   private final static int PORT = 3333;
 
@@ -50,7 +51,7 @@ public class TvdbServiceItTest {
 
     // inicializamos mocks y servicios
     ws = WS.newClient(PORT);
-    df = mock(SimpleDateFormat.class);
+    jsonUtils = mock(JsonUtils.class);
 
     // inicializamos base de datos de prueba
     databaseTester = new JndiDatabaseTester("DefaultDS");
@@ -79,7 +80,7 @@ public class TvdbServiceItTest {
     running(testServer(PORT, fakeApplication(inMemoryDatabase())), new HtmlUnitDriver(), browser -> {
       browser.goTo("http://localhost:" + PORT);
 
-      TvdbService tvdbService = new TvdbService(ws, df, Play.current().injector().instanceOf(TvdbConnection.class));
+      TvdbService tvdbService = new TvdbService(ws, jsonUtils, Play.current().injector().instanceOf(TvdbConnection.class));
 
       jpa.withTransaction(() -> {
         try {
@@ -99,7 +100,7 @@ public class TvdbServiceItTest {
     running(testServer(PORT, fakeApplication(inMemoryDatabase())), new HtmlUnitDriver(), browser -> {
       browser.goTo("http://localhost:" + PORT);
 
-      TvdbService tvdbService = new TvdbService(ws, df, Play.current().injector().instanceOf(TvdbConnection.class));
+      TvdbService tvdbService = new TvdbService(ws, jsonUtils, Play.current().injector().instanceOf(TvdbConnection.class));
 
       jpa.withTransaction(() -> {
         try {
@@ -118,7 +119,7 @@ public class TvdbServiceItTest {
     running(testServer(PORT, fakeApplication(inMemoryDatabase())), new HtmlUnitDriver(), browser -> {
       browser.goTo("http://localhost:" + PORT);
 
-      TvdbService tvdbService = new TvdbService(ws, df, Play.current().injector().instanceOf(TvdbConnection.class));
+      TvdbService tvdbService = new TvdbService(ws, jsonUtils, Play.current().injector().instanceOf(TvdbConnection.class));
 
       jpa.withTransaction(() -> {
         try {


### PR DESCRIPTION
Se requiere extraer dicha función ya que se repite en varias clases de los servicios externos. Se hará en una nueva clase `JsonUtils`.

Algunas mejoras de estas mismas clases de servicios externos:

- Votación de imágenes `Double` para una mayor exactitud a la hora de comparar
- Unidad de persistencia set on `validate` para probar en Heroku
- Mejoras y ajustes de la vista responsive móvil de Administración