### PR TITLE
Seasons - controller y routes

### DIFF
--- a/app/controllers/SeasonController.java
+++ b/app/controllers/SeasonController.java
@@ -27,7 +27,35 @@ public class SeasonController {
     this.jsonUtils = jsonUtils;
   }
 
-  // devolver un TV Show por id
+  // devolver todas las temporadas de una serie (información reducida)
+  @Transactional(readOnly = true)
+  @Security.Authenticated(Roles.class)
+  public Result allTvShowSeasons(Integer tvShowId) {
+    TvShow tvShow = tvShowService.find(tvShowId);
+    if (tvShow == null) {
+      ObjectNode result = Json.newObject();
+      result.put("error", "Not found");
+      return notFound(result);
+    }
+
+    try {
+      JsonNode jsonNode = jsonUtils.jsonParseObject(tvShow.seasons, JsonViews.FullTvShow.class);
+      if (jsonNode == null) {
+        ObjectNode result = Json.newObject();
+        result.put("error", "Not found");
+        return notFound(result);
+      } else {
+        return ok(jsonNode);
+      }
+    } catch (Exception ex) {
+      // si hubiese un error, devolver error interno
+      ObjectNode result = Json.newObject();
+      result.put("error", "It can't be processed");
+      return internalServerError(result);
+    }
+  }
+
+  // devolver una temporada por tv show id y numero de temporada
   @Transactional(readOnly = true)
   @Security.Authenticated(Roles.class)
   public Result seasonByTvShowIdAndSeasonNumber(Integer tvShowId, Integer seasonNumber) {

--- a/app/controllers/SeasonController.java
+++ b/app/controllers/SeasonController.java
@@ -1,0 +1,58 @@
+package controllers;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.inject.Inject;
+import models.TvShow;
+import models.service.SeasonService;
+import models.service.TvShowService;
+import play.db.jpa.Transactional;
+import play.libs.Json;
+import play.mvc.Result;
+import play.mvc.Security;
+import utils.Security.Roles;
+import utils.json.JsonViews;
+
+import static play.mvc.Results.*;
+
+public class SeasonController {
+  private final SeasonService seasonService;
+  private final TvShowService tvShowService;
+  private final utils.json.Utils jsonUtils;
+
+  @Inject
+  public SeasonController(SeasonService seasonService, TvShowService tvShowService, utils.json.Utils jsonUtils) {
+    this.seasonService = seasonService;
+    this.tvShowService = tvShowService;
+    this.jsonUtils = jsonUtils;
+  }
+
+  // devolver un TV Show por id
+  @Transactional(readOnly = true)
+  @Security.Authenticated(Roles.class)
+  public Result seasonByTvShowIdAndSeasonNumber(Integer tvShowId, Integer seasonNumber) {
+    TvShow tvShow = tvShowService.find(tvShowId);
+    if (tvShow == null) {
+      ObjectNode result = Json.newObject();
+      result.put("error", "Not found");
+      return notFound(result);
+    }
+
+    try {
+      JsonNode jsonNode = jsonUtils.jsonParseObject(seasonService.getSeasonByNumber(tvShow, seasonNumber), JsonViews.FullAll.class);
+      if (jsonNode != null) {
+        return ok(jsonNode);
+      } else {
+        ObjectNode result = Json.newObject();
+        result.put("error", "Not found");
+        return notFound(result);
+      }
+    } catch (Exception ex) {
+      // si hubiese un error, devolver error interno
+      ObjectNode result = Json.newObject();
+      result.put("error", "It can't be processed");
+      return internalServerError(result);
+    }
+  }
+
+}

--- a/app/models/Season.java
+++ b/app/models/Season.java
@@ -2,7 +2,9 @@ package models;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonView;
 import play.data.validation.Constraints;
+import utils.json.JsonViews;
 
 import javax.persistence.*;
 import java.util.Date;
@@ -23,13 +25,16 @@ public class Season {
   @Constraints.Required
   public Integer seasonNumber;
 
+  @JsonView(JsonViews.FullAll.class)
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   public Date firstAired;
 
   public String poster;
 
+  @JsonView(JsonViews.FullAll.class)
   public String name;
 
+  @JsonView(JsonViews.FullAll.class)
   @Column(columnDefinition = "text")
   public String overview;
 

--- a/app/models/service/SeasonService.java
+++ b/app/models/service/SeasonService.java
@@ -60,6 +60,14 @@ public class SeasonService {
     return seasonDAO.find(id);
   }
 
+  // obtener por season number
+  public Season getSeasonByNumber(TvShow tvShow, Integer seasonNumber) {
+    if (tvShow != null && tvShow.seasons != null) {
+      return tvShow.seasons.stream().filter(season -> season.seasonNumber.equals(seasonNumber)).findAny().orElse(null);
+    }
+    return null;
+  }
+
   // Delete por id
   public Boolean delete(Integer id) {
     Season season = seasonDAO.find(id);

--- a/conf/routes
+++ b/conf/routes
@@ -22,6 +22,7 @@ PUT     /api/tvshows/:id                    controllers.TvShowController.updateD
 DELETE  /api/tvshows/:id                    controllers.TvShowController.delete(id: Integer)
 
 # TV Shows Seasons ----------------
+GET     /api/tvshows/:id/seasons            controllers.SeasonController.allTvShowSeasons(id: Integer)
 GET     /api/tvshows/:id/seasons/:number    controllers.SeasonController.seasonByTvShowIdAndSeasonNumber(id: Integer, number: Integer)
 
 # TV Show Votes -------------------

--- a/conf/routes
+++ b/conf/routes
@@ -3,50 +3,53 @@
 # ~~~~
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file                   controllers.Assets.versioned(path="/public", file: Asset)
+GET     /assets/*file                       controllers.Assets.versioned(path="/public", file: Asset)
 
 # API documentation with Swagger --
-GET     /api/docs                        controllers.Default.redirect(to = "docs/")
-GET     /api/docs/                       controllers.Assets.at(path="/public/docs", file = "index.html")
-GET     /api/docs/*file                  controllers.Assets.at(path="/public/docs", file)
+GET     /api/docs                           controllers.Default.redirect(to = "docs/")
+GET     /api/docs/                          controllers.Assets.at(path="/public/docs", file = "index.html")
+GET     /api/docs/*file                     controllers.Assets.at(path="/public/docs", file)
 
 # API root ------------------------
-GET     /api                            controllers.Default.redirect(to = "api/")
-GET     /api/                           controllers.RootController.index
+GET     /api                                controllers.Default.redirect(to = "api/")
+GET     /api/                               controllers.RootController.index
 
 # TV Shows ------------------------
-GET     /api/tvshows                    controllers.TvShowController.all(search: String ?= "", tvdb: Integer ?= 0)
-POST    /api/tvshows                    controllers.TvShowController.create
-GET     /api/tvshows/:id                controllers.TvShowController.tvShowById(id: Integer)
-PUT     /api/tvshows/:id                controllers.TvShowController.updateData(id: Integer)
-DELETE  /api/tvshows/:id                controllers.TvShowController.delete(id: Integer)
+GET     /api/tvshows                        controllers.TvShowController.all(search: String ?= "", tvdb: Integer ?= 0)
+POST    /api/tvshows                        controllers.TvShowController.create
+GET     /api/tvshows/:id                    controllers.TvShowController.tvShowById(id: Integer)
+PUT     /api/tvshows/:id                    controllers.TvShowController.updateData(id: Integer)
+DELETE  /api/tvshows/:id                    controllers.TvShowController.delete(id: Integer)
+
+# TV Shows Seasons ----------------
+GET     /api/tvshows/:id/seasons/:number    controllers.SeasonController.seasonByTvShowIdAndSeasonNumber(id: Integer, number: Integer)
 
 # TV Show Votes -------------------
-GET     /api/tvshows/:tvShowId/rating   controllers.TvShowVoteController.getTvShowVote(tvShowId: Integer)
-PUT     /api/tvshows/:tvShowId/rating   controllers.TvShowVoteController.voteTvShow(tvShowId: Integer)
-DELETE  /api/tvshows/:tvShowId/rating   controllers.TvShowVoteController.deleteTvShowVote(tvShowId: Integer)
+GET     /api/tvshows/:tvShowId/rating       controllers.TvShowVoteController.getTvShowVote(tvShowId: Integer)
+PUT     /api/tvshows/:tvShowId/rating       controllers.TvShowVoteController.voteTvShow(tvShowId: Integer)
+DELETE  /api/tvshows/:tvShowId/rating       controllers.TvShowVoteController.deleteTvShowVote(tvShowId: Integer)
 
 # The TVDB API --------------------
-GET     /api/tvshows/tvdb/:tvdbId       controllers.TvdbController.tvShowById(tvdbId: Integer)
+GET     /api/tvshows/tvdb/:tvdbId           controllers.TvdbController.tvShowById(tvdbId: Integer)
 
 # TV Show requests ----------------
-POST    /api/requests                   controllers.TvShowRequestController.create
-PATCH   /api/requests/:id               controllers.TvShowRequestController.update(id: Integer)
-PUT     /api/requests/:id/newtvshow     controllers.TvShowRequestController.newTvShow(id: Integer)
+POST    /api/requests                       controllers.TvShowRequestController.create
+PATCH   /api/requests/:id                   controllers.TvShowRequestController.update(id: Integer)
+PUT     /api/requests/:id/newtvshow         controllers.TvShowRequestController.newTvShow(id: Integer)
 
 # Users ---------------------------
-POST    /api/users                      controllers.UserController.register
-POST    /api/users/session              controllers.UserController.login
-GET     /api/users/session              controllers.UserController.verifySession
+POST    /api/users                          controllers.UserController.register
+POST    /api/users/session                  controllers.UserController.login
+GET     /api/users/session                  controllers.UserController.verifySession
 
 # Evolutions
-GET     /api/evolutions                 controllers.EvolutionController.getEvolutions(status: String ?= "")
-PATCH   /api/evolutions                 controllers.EvolutionController.applyEvolutionJSON
+GET     /api/evolutions                     controllers.EvolutionController.getEvolutions(status: String ?= "")
+PATCH   /api/evolutions                     controllers.EvolutionController.applyEvolutionJSON
 
 # Admin client
-GET     /                               controllers.Default.redirect(to = "admin")
-GET     /admin/login                    controllers.AdminController.loginView
-GET     /admin                          controllers.AdminController.index
-GET     /admin/tvShows                  controllers.AdminController.tvShows
-GET     /admin/tvShows/:id              controllers.AdminController.tvShow(id: Integer)
-GET     /admin/tvShowRequests           controllers.AdminController.tvShowRequests
+GET     /                                   controllers.Default.redirect(to = "admin")
+GET     /admin/login                        controllers.AdminController.loginView
+GET     /admin                              controllers.AdminController.index
+GET     /admin/tvShows                      controllers.AdminController.tvShows
+GET     /admin/tvShows/:id                  controllers.AdminController.tvShow(id: Integer)
+GET     /admin/tvShowRequests               controllers.AdminController.tvShowRequests

--- a/docs/api-doc-versions/v0.10.7.yaml
+++ b/docs/api-doc-versions/v0.10.7.yaml
@@ -1,0 +1,1158 @@
+# Example YAML to get you started quickly.
+# Be aware that YAML has indentation based scoping.
+# Code completion support is available so start typing for available options.
+swagger: "2.0"
+
+# This is your document metadata
+info:
+  version: "0.10.7"
+  title: TFG Trending Series API v0 `Offline`
+  description: >-
+    The API is accessible via https://darkhollow.github.com/tfg-series-playAPI/ and provides the
+    following `REST` endpoints in `JSON` format.
+
+
+
+    How to use this API documentation
+
+    ----------------
+
+
+
+    You may browse the API routes freely without any authentication.
+
+
+    You will **NOT** be able to use the routes to send requests to the API and
+    get a response and use authentication neither,
+    because this is an `Offline Documentation` for `Github Pages`.
+
+    Because of that, the button `Try it out` and the button for authentication is disabled in all the routes.
+
+
+
+    Versioning
+
+    ----------------
+
+
+
+    This documentation automatically uses the version seen in the title tag
+    at the top of the page.
+
+
+
+    About this project
+
+    ----------------
+
+
+
+    This [API](https://github.com/DarkHollow/tfg-series-playAPI) and API documentation is part of a `TFG (Final Degree Project)`
+    of Software Engineering by [Roberto Cánovas](https://github.com/DarkHollow/) at
+    the University of Alicante (Spain).
+
+
+    You can contact me at [Github](https://github.com/DarkHollow/), e-mail rcanovas.corp@gmail.com or [Twitter](https://twitter.com/RobCanovas).
+
+
+    #### Status: work in progress
+
+
+basePath: /api
+tags:
+  - name: root
+    description: Status of the API
+  - name: TV Shows
+    description: Information and routes for handling TV Shows data
+  - name: Seasons
+    description: Information and routes for handling TV Show Seasons data
+  - name: Requests
+    description: Information and routes for handling TV Show Requests data
+  - name: Users
+    description: Information and routes for handling Users data
+  - name: Evolutions
+    description: Information and routes for handling Evolutions
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /:
+    get:
+      tags:
+        - root
+      description: >-
+        Returns the status of the API and a link to the documentation
+      responses:
+        '200':
+          description: JSON response with status and doc link keys
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: status of the API
+              API_doc:
+                type: string
+                description: link to the documentation
+  /tvshows:
+    get:
+      tags:
+        - TV Shows
+      description: >-
+        Returns basic information about TV Shows and search
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: search
+          in: query
+          required: false
+          description: search by name (optional)
+          type: string
+        - name: tvdb
+          in: query
+          required: false
+          description: set to 1 to search on TVDB (optional)
+          type: integer
+      responses:
+        '200':
+          description: JSON response with an array of TV Shows
+          schema:
+            $ref: '#/definitions/TvShowsArray'
+        '401':
+          description: JSON response with Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+    post:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Creates a new TV Show **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: JSON containing the TV Show to be created
+          schema:
+            $ref: '#/definitions/TvShowBody'
+      responses:
+        '201':
+          description: JSON response with the resolution of the creation
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '500':
+          description: JSON response with 500 Internal Server Error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}:
+    get:
+      tags:
+        - TV Shows
+      description: >-
+        Returns all information about a particular TV Show by id
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the TV Show
+          schema:
+            $ref: '#/definitions/TvShow'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+    put:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Updates the required data of a TV Show **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the TV Show
+          type: integer
+        - in: body
+          name: update
+          description: part of the data to update (basic data, images)
+          schema:
+            $ref: '#/definitions/TvShowUpdateBody'
+      responses:
+        '200':
+          description: JSON response with TV Show updated
+          schema:
+            $ref: '#/definitions/TvShow'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '504':
+          description: JSON response with 504 Gateway Timeout error
+          schema:
+            $ref: '#/definitions/GatewayTimeoutError'
+    delete:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Delete a TV Show **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with successful delete
+          schema:
+            $ref: '#/definitions/Ok'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}/rating:
+    get:
+      tags:
+        - TV Shows
+      description: >-
+        Returns the TV Show rating for the authenticated user
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the TV Show rating for the authenticated user
+          schema:
+            $ref: '#/definitions/TvShowRating'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+    put:
+      tags:
+        - TV Shows
+      description: >-
+        Rate or modify the actual rating of a TV Show for the authenticated user
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+        - in: body
+          name: score
+          description: new rating
+          schema:
+            $ref: '#/definitions/RatingPutBody'
+      responses:
+        '200':
+          description: JSON response of rating modified successfully
+          schema:
+            $ref: '#/definitions/TvShowRating'
+        '201':
+          description: JSON response of rating created successfully
+          schema:
+            $ref: '#/definitions/TvShowRating'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+    delete:
+      tags:
+        - TV Shows
+      description: >-
+        Delete a rating for the authenticated user
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with successful delete
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/tvdb/{tvdbId}:
+    get:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Returns all information about a particular TV Show on TVDB by tvdbId **(only admin)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: tvdbId
+          in: path
+          required: true
+          description: tvdbId of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the TV Show by TVDB
+          schema:
+            $ref: '#/definitions/TvShowTvdb'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}/seasons:
+    get:
+      tags:
+        - Seasons
+      description: >-
+        Returns simple information about all TV Shows Seasons
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with an array of seasons information
+          schema:
+            $ref: '#/definitions/ArraySimpleSeason'
+        '401':
+          description: JSON response with Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}/seasons/{number}:
+    get:
+      tags:
+        - Seasons
+      description: >-
+        Returns complete information about a TV Shows Season by number
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+        - name: number
+          in: path
+          required: true
+          description: season number of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with all season information
+          schema:
+            $ref: '#/definitions/CompleteSeason'
+        '401':
+          description: JSON response with Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /requests:
+    post:
+      tags:
+        - Requests
+      description: >-
+        Request a new TV show
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: TV Show request body
+          in: body
+          required: true
+          description: JSON string containing the request parameters
+          schema:
+            $ref: '#/definitions/TvShowRequestBody'
+      responses:
+        '201':
+          description: JSON response with the resolution of the request
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 404 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '504':
+          description: JSON response with 504 Gateway Timeout error
+          schema:
+            $ref: '#/definitions/GatewayTimeoutError'
+  /requests/{id}:
+    patch:
+      tags:
+        - Requests
+      summary: 👨🏻‍💻
+      description: >-
+        Updates the status of a request **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the TV Show
+          type: integer
+        - in: body
+          name: status
+          description: new status
+          schema:
+            $ref: '#/definitions/RequestPatchBody'
+      responses:
+        '200':
+          description: JSON response with TV Show updated info
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /requests/{id}/newtvshow:
+    put:
+      tags:
+        - Requests
+      summary: 👨🏻‍💻
+      description: >-
+        Updates the status of a request **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the TV Show
+          type: integer
+        - in: body
+          name: status
+          description: new status
+          schema:
+            $ref: '#/definitions/RequestPatchBody'
+      responses:
+        '200':
+          description: JSON response with TV Show created and more info
+          schema:
+            $ref: '#/definitions/TvShowCreated'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+        '504':
+          description: JSON response with 504 Gateway Timeout error
+          schema:
+            $ref: '#/definitions/GatewayTimeoutError'
+  /users:
+    post:
+      tags:
+        - Users
+      description: >-
+        Register a new user
+      parameters:
+        - name: User register body
+          in: body
+          required: true
+          description: JSON string containing the register parameters
+          schema:
+            $ref: '#/definitions/UserRegisterBody'
+      responses:
+        '200':
+          description: JSON response with the resolution of the request
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+  /users/session:
+    get:
+      tags:
+        - Users
+      description: >-
+        Returns information about the actual JWT/session (user authenticated or not authenticated)
+      responses:
+        '200':
+          description: JSON response with the information of the actual session
+          schema:
+            $ref: '#/definitions/Ok'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+    post:
+      tags:
+        - Users
+      description: >-
+        Authenticate an user
+
+        You can use [SHA512 Hash Generator](https://passwordsgenerator.net/sha512-hash-generator/) to hash the password
+      parameters:
+        - name: User authentication body
+          in: body
+          required: true
+          description: >-
+            JSON string containing the authentication parameters: e-mail string and password [hashed with SHA512](https://passwordsgenerator.net/sha512-hash-generator/)
+          schema:
+            $ref: '#/definitions/UserAuthenticationBody'
+      responses:
+        '200':
+          description: JSON response with the resolution of the request
+          schema:
+            $ref: '#/definitions/UserAuthenticated'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /evolutions:
+    get:
+      tags:
+        - Evolutions
+      summary: 👨🏻‍💻
+      description: >-
+        Returns information about evolutions or filter for not applied evolutions
+
+        ### Permitted status values
+
+        - not-applied
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: status filter
+          type: string
+      responses:
+        '200':
+          description: JSON response with the evolutions
+          schema:
+            $ref: '#/definitions/Evolutions'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+    patch:
+      tags:
+        - Evolutions
+      summary: 👨🏻‍💻
+      description: >-
+        Apply a not applied evolution
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: body
+          name: evolutionId
+          description: id of the evolution to apply
+          schema:
+            $ref: '#/definitions/EvolutionPatchBody'
+      responses:
+        '200':
+          description: JSON response with TV Show updated info
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+definitions:
+  Ok:
+    properties:
+      ok:
+        type: string
+  BadRequest:
+    properties:
+      error:
+        type: string
+  Unauthorized:
+    properties:
+      error:
+        type: string
+      type:
+        type: string
+      message:
+        type: string
+  NotFound:
+    properties:
+      error:
+        type: string
+  InternalServerError:
+    properties:
+      error:
+        type: string
+  GatewayTimeoutError:
+    properties:
+      error:
+        type: string
+  TvShowRequestBody:
+    properties:
+      tvdbId:
+        type: integer
+  TvShowsArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: TV Show id
+        name:
+          type: string
+          description: name of the TV Show
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+        score:
+          type: number
+          description: average rating
+        voteCount:
+          type: integer
+          description: number of ratings
+  TvdbTvShowsArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: TV Show id
+        tvdbId:
+          type: integer
+          description: TVDB id
+        name:
+          type: string
+          description: name of the TV Show
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+        local:
+          type: boolean
+          description: true if the tvShows is in our bbdd
+        requested:
+          type: boolean
+          description: true if the tvShows is requested by users
+  TvShow:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: TV Show id
+      tvdbId:
+        type: integer
+        description: TV Show id on The TVDB API
+      name:
+        type: string
+        description: name of the TV Show
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the TV Show
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the TV Show airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the TV Show
+      rating:
+        type: string
+        description: TV Parental Guideline
+      status:
+        type: string
+        description: status of the TV Show (continuing or ended)
+      score:
+        type: number
+        description: average rating
+      voteCount:
+        type: integer
+        description: number of ratings
+      tvShowVotes:
+        type: array
+        items:
+          type: object
+          properties:
+            score:
+              type: number
+              description: score rating
+      seasons:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+              description: season id
+            seasonNumber:
+              type: integer
+              description: season number
+            poster:
+              type: string
+              description: relative url of the season poster image
+  TvShowCreated:
+    type: object
+    properties:
+      ok:
+        type: string
+      banner:
+        type: boolean
+      poster:
+        type: boolean
+      fanart:
+        type: boolean
+      tvShow:
+        type: object
+        properties:
+          id:
+            type: integer
+            description: TV Show id
+          tvdbId:
+            type: integer
+            description: TV Show id on The TVDB API
+          name:
+            type: string
+            description: name of the TV Show
+          firstAired:
+            type: string
+            description: first aired date
+          overview:
+            type: string
+            description: a summary of the TV Show
+          banner:
+            type: string
+            description: relative url of the banner image
+          poster:
+            type: string
+            description: relative url of the poster image
+          fanart:
+            type: string
+            description: relative url of the fanart image
+          network:
+            type: string
+            description: network where the TV Show airs
+          runtime:
+            type: integer
+            description: average episode runtime
+          genre:
+            type: array
+            items:
+              type: string
+            description: genres of the TV Show
+          rating:
+            type: string
+            description: TV Parental Guideline
+          status:
+            type: string
+            description: status of the TV Show (continuing or ended)
+          score:
+            type: number
+            description: average rating
+          voteCount:
+            type: integer
+            description: number of ratings
+          tvShowVotes:
+            type: array
+            items:
+              type: object
+              properties:
+                score:
+                  type: number
+                  description: score rating
+          seasons:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  description: season id
+                seasonNumber:
+                  type: integer
+                  description: season number
+                poster:
+                  type: string
+                  description: relative url of the season poster image
+  TvShowBody:
+    type: object
+    properties:
+      name:
+        type: string
+        description: name of the TV Show
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the TV Show
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the TV Show airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the TV Show
+      status:
+        type: string
+        description: status of the TV Show (continuing or ended)
+  TvShowUpdateBody:
+    type: object
+    properties:
+      update:
+        type: string
+        description: data or images
+  CompleteSeason:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: season id
+      seasonNumber:
+        type: integer
+        description: season number
+      firstAired:
+        type: string
+        description: season first aired date
+      poster:
+        type: string
+        description: relative url of the season poster image
+      name:
+        type: string
+        description: season name
+      overview:
+        type: string
+        description: a summary of the season
+  ArraySimpleSeason:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: season id
+        seasonNumber:
+          type: integer
+          description: season number
+        poster:
+          type: string
+          description: relative url of the season poster image
+  TvShowRating:
+    type: object
+    properties:
+      ok:
+        type: string
+      tvShowVote:
+        type: object
+        properties:
+          id:
+            type: integer
+          tvShowId:
+            type: integer
+          userId:
+            type: integer
+          score:
+            type: number
+  TvShowTvdb:
+    type: object
+    properties:
+      tvdbId:
+        type: integer
+        description: TVDB id
+      name:
+        type: string
+        description: name of the TV Show
+      firstAired:
+        type: string
+        description: first aired date
+      banner:
+        type: string
+        description: relative url of the banner image from TVDB
+  UserAuthenticated:
+    type: object
+    properties:
+      ok:
+        type: string
+        description: response
+      type:
+        type: string
+        description: response status
+      message:
+        type: string
+        description: response message
+      Authorization:
+        type: string
+        description: JWT generated
+      userId:
+        type: integer
+        description: user id
+      userName:
+        type: string
+        description: user name
+      userRol:
+        type: string
+        description: user rol
+  Evolutions:
+    type: object
+    properties:
+      evolutions:
+        type: object
+        properties:
+          id:
+            type: integer
+            description: id of the evolution
+          version:
+            type: integer
+            description: version of the evolution
+          state:
+            type: string
+            description: state of the evolution like not-applied, applied, etc.
+      actualVersion:
+        type: string
+        description: actual version of the database
+      newVersion:
+        type: string
+        description: new version to be applied if exists
+  EvolutionPatchBody:
+    properties:
+      evolutionId:
+        type: integer
+        description: id of the evolution to be applied
+  RatingPutBody:
+    properties:
+      score:
+        type: number
+        description: new TV Show rating
+  UserRegisterBody:
+    properties:
+      email:
+        type: string
+        description: new user's email
+      password:
+        type: string
+        description: SHA512 hashed password
+      name:
+        type: string
+        description: new user's name
+  UserAuthenticationBody:
+    properties:
+      email:
+        type: string
+        description: user's email
+      password:
+        type: string
+        description: SHA512 hashed password
+  RequestPatchBody:
+    properties:
+      status:
+        type: string
+        description: new request status
+securityDefinitions:
+  jwtAuth:
+    type: apiKey
+    in: header
+    name: Authorization

--- a/docs/index.html
+++ b/docs/index.html
@@ -74,7 +74,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "./api-doc-versions/v0.10.0.yaml",
+    url: "./api-doc-versions/v0.10.7.yaml",
     docExpansion: 'none',
     dom_id: '#swagger-ui',
     deepLinking: true,

--- a/public/docs/api-doc-versions/v0.10.7.yaml
+++ b/public/docs/api-doc-versions/v0.10.7.yaml
@@ -1,0 +1,1174 @@
+# Example YAML to get you started quickly.
+# Be aware that YAML has indentation based scoping.
+# Code completion support is available so start typing for available options.
+swagger: "2.0"
+
+# This is your document metadata
+info:
+  version: "0.10.7"
+  title: TFG Trending Series API v0
+  description: >-
+    The API provides the
+    following `REST` endpoints in `JSON` format.
+
+
+
+    How to use this API documentation
+
+    ----------------
+
+
+
+    You may browse the API routes without authentication, but if you wish to
+    send requests to the API and see response data, then you must authenticate.
+
+
+    Whether you have a user account or and administrator accout, you must:
+
+    - Obtain a JWT by `POST`ing to the `/users/session` route at the `Users` section
+
+    - Then, authorize the requests clicking on the **Authorize 🔓** button and enter the JWT with the following format
+
+
+    ```
+    Bearer yourJWT
+    ```
+
+
+    And then, you will be able to use all the routes to send requests to the API and get
+    a response for thouse routes your account has access (user or administrator).
+
+
+    As an information, the icon 👨🏻‍💻 will be displayed to indicate an admintration operation.
+
+
+    _If you don't have an user account, create it at the `Users` section_
+
+
+
+    Versioning
+
+    ----------------
+
+
+
+    This documentation automatically uses the version seen in the title tag
+    at the top of the page.
+
+
+
+    About this project
+
+    ----------------
+
+
+
+    This [API](https://github.com/DarkHollow/tfg-series-playAPI) and API documentation is part of a `TFG (Final Degree Project)`
+    of Software Engineering by [Roberto Cánovas](https://github.com/DarkHollow/) at
+    the University of Alicante (Spain).
+
+
+    You can contact me at [Github](https://github.com/DarkHollow/), e-mail rcanovas.corp@gmail.com or [Twitter](https://twitter.com/RobCanovas).
+
+
+    #### Status: work in progress
+
+
+basePath: /api
+tags:
+  - name: root
+    description: Status of the API
+  - name: TV Shows
+    description: Information and routes for handling TV Shows data
+  - name: Seasons
+    description: Information and routes for handling TV Show Seasons data
+  - name: Requests
+    description: Information and routes for handling TV Show Requests data
+  - name: Users
+    description: Information and routes for handling Users data
+  - name: Evolutions
+    description: Information and routes for handling Evolutions
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /:
+    get:
+      tags:
+        - root
+      description: >-
+        Returns the status of the API and a link to the documentation
+      responses:
+        '200':
+          description: JSON response with status and doc link keys
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                description: status of the API
+              API_doc:
+                type: string
+                description: link to the documentation
+  /tvshows:
+    get:
+      tags:
+        - TV Shows
+      description: >-
+        Returns basic information about TV Shows and search
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: search
+          in: query
+          required: false
+          description: search by name (optional)
+          type: string
+        - name: tvdb
+          in: query
+          required: false
+          description: set to 1 to search on TVDB (optional)
+          type: integer
+      responses:
+        '200':
+          description: JSON response with an array of TV Shows
+          schema:
+            $ref: '#/definitions/TvShowsArray'
+        '401':
+          description: JSON response with Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+    post:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Creates a new TV Show **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: body
+          in: body
+          required: true
+          description: JSON containing the TV Show to be created
+          schema:
+            $ref: '#/definitions/TvShowBody'
+      responses:
+        '201':
+          description: JSON response with the resolution of the creation
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '500':
+          description: JSON response with 500 Internal Server Error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}:
+    get:
+      tags:
+        - TV Shows
+      description: >-
+        Returns all information about a particular TV Show by id
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the TV Show
+          schema:
+            $ref: '#/definitions/TvShow'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+    put:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Updates the required data of a TV Show **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the TV Show
+          type: integer
+        - in: body
+          name: update
+          description: part of the data to update (basic data, images)
+          schema:
+            $ref: '#/definitions/TvShowUpdateBody'
+      responses:
+        '200':
+          description: JSON response with TV Show updated
+          schema:
+            $ref: '#/definitions/TvShow'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '504':
+          description: JSON response with 504 Gateway Timeout error
+          schema:
+            $ref: '#/definitions/GatewayTimeoutError'
+    delete:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Delete a TV Show **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with successful delete
+          schema:
+            $ref: '#/definitions/Ok'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}/rating:
+    get:
+      tags:
+        - TV Shows
+      description: >-
+        Returns the TV Show rating for the authenticated user
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the TV Show rating for the authenticated user
+          schema:
+            $ref: '#/definitions/TvShowRating'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+    put:
+      tags:
+        - TV Shows
+      description: >-
+        Rate or modify the actual rating of a TV Show for the authenticated user
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+        - in: body
+          name: score
+          description: new rating
+          schema:
+            $ref: '#/definitions/RatingPutBody'
+      responses:
+        '200':
+          description: JSON response of rating modified successfully
+          schema:
+            $ref: '#/definitions/TvShowRating'
+        '201':
+          description: JSON response of rating created successfully
+          schema:
+            $ref: '#/definitions/TvShowRating'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+    delete:
+      tags:
+        - TV Shows
+      description: >-
+        Delete a rating for the authenticated user
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: ID of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with successful delete
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/tvdb/{tvdbId}:
+    get:
+      tags:
+        - TV Shows
+      summary: 👨🏻‍💻
+      description: >-
+        Returns all information about a particular TV Show on TVDB by tvdbId **(only admin)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: tvdbId
+          in: path
+          required: true
+          description: tvdbId of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with the information of the TV Show by TVDB
+          schema:
+            $ref: '#/definitions/TvShowTvdb'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}/seasons:
+    get:
+      tags:
+        - Seasons
+      description: >-
+        Returns simple information about all TV Shows Seasons
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with an array of seasons information
+          schema:
+            $ref: '#/definitions/ArraySimpleSeason'
+        '401':
+          description: JSON response with Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /tvshows/{id}/seasons/{number}:
+    get:
+      tags:
+        - Seasons
+      description: >-
+        Returns complete information about a TV Shows Season by number
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: id of the TV Show
+          type: integer
+        - name: number
+          in: path
+          required: true
+          description: season number of the TV Show
+          type: integer
+      responses:
+        '200':
+          description: JSON response with all season information
+          schema:
+            $ref: '#/definitions/CompleteSeason'
+        '401':
+          description: JSON response with Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /requests:
+    post:
+      tags:
+        - Requests
+      description: >-
+        Request a new TV show
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: TV Show request body
+          in: body
+          required: true
+          description: JSON string containing the request parameters
+          schema:
+            $ref: '#/definitions/TvShowRequestBody'
+      responses:
+        '201':
+          description: JSON response with the resolution of the request
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 404 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '504':
+          description: JSON response with 504 Gateway Timeout error
+          schema:
+            $ref: '#/definitions/GatewayTimeoutError'
+  /requests/{id}:
+    patch:
+      tags:
+        - Requests
+      summary: 👨🏻‍💻
+      description: >-
+        Updates the status of a request **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the TV Show
+          type: integer
+        - in: body
+          name: status
+          description: new status
+          schema:
+            $ref: '#/definitions/RequestPatchBody'
+      responses:
+        '200':
+          description: JSON response with TV Show updated info
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /requests/{id}/newtvshow:
+    put:
+      tags:
+        - Requests
+      summary: 👨🏻‍💻
+      description: >-
+        Updates the status of a request **(admin only)**
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: ID of the TV Show
+          type: integer
+        - in: body
+          name: status
+          description: new status
+          schema:
+            $ref: '#/definitions/RequestPatchBody'
+      responses:
+        '200':
+          description: JSON response with TV Show created and more info
+          schema:
+            $ref: '#/definitions/TvShowCreated'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+        '504':
+          description: JSON response with 504 Gateway Timeout error
+          schema:
+            $ref: '#/definitions/GatewayTimeoutError'
+  /users:
+    post:
+      tags:
+        - Users
+      description: >-
+        Register a new user
+      parameters:
+        - name: User register body
+          in: body
+          required: true
+          description: JSON string containing the register parameters
+          schema:
+            $ref: '#/definitions/UserRegisterBody'
+      responses:
+        '200':
+          description: JSON response with the resolution of the request
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+  /users/session:
+    get:
+      tags:
+        - Users
+      description: >-
+        Returns information about the actual JWT/session (user authenticated or not authenticated)
+      responses:
+        '200':
+          description: JSON response with the information of the actual session
+          schema:
+            $ref: '#/definitions/Ok'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+    post:
+      tags:
+        - Users
+      description: >-
+        Authenticate an user
+
+        You can use [SHA512 Hash Generator](https://passwordsgenerator.net/sha512-hash-generator/) to hash the password
+      parameters:
+        - name: User authentication body
+          in: body
+          required: true
+          description: >-
+            JSON string containing the authentication parameters: e-mail string and password [hashed with SHA512](https://passwordsgenerator.net/sha512-hash-generator/)
+          schema:
+            $ref: '#/definitions/UserAuthenticationBody'
+      responses:
+        '200':
+          description: JSON response with the resolution of the request
+          schema:
+            $ref: '#/definitions/UserAuthenticated'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+  /evolutions:
+    get:
+      tags:
+        - Evolutions
+      summary: 👨🏻‍💻
+      description: >-
+        Returns information about evolutions or filter for not applied evolutions
+
+        ### Permitted status values
+
+        - not-applied
+      security:
+        - jwtAuth: []
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: status filter
+          type: string
+      responses:
+        '200':
+          description: JSON response with the evolutions
+          schema:
+            $ref: '#/definitions/Evolutions'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+    patch:
+      tags:
+        - Evolutions
+      summary: 👨🏻‍💻
+      description: >-
+        Apply a not applied evolution
+      security:
+        - jwtAuth: []
+      parameters:
+        - in: body
+          name: evolutionId
+          description: id of the evolution to apply
+          schema:
+            $ref: '#/definitions/EvolutionPatchBody'
+      responses:
+        '200':
+          description: JSON response with TV Show updated info
+          schema:
+            $ref: '#/definitions/Ok'
+        '400':
+          description: JSON response with 400 Bad Request error
+          schema:
+            $ref: '#/definitions/BadRequest'
+        '401':
+          description: JSON response with 401 Unauthorized error
+          schema:
+            $ref: '#/definitions/Unauthorized'
+        '404':
+          description: JSON response with 404 Not Found error
+          schema:
+            $ref: '#/definitions/NotFound'
+        '500':
+          description: JSON response with 500 Internal Server error
+          schema:
+            $ref: '#/definitions/InternalServerError'
+definitions:
+  Ok:
+    properties:
+      ok:
+        type: string
+  BadRequest:
+    properties:
+      error:
+        type: string
+  Unauthorized:
+    properties:
+      error:
+        type: string
+      type:
+        type: string
+      message:
+        type: string
+  NotFound:
+    properties:
+      error:
+        type: string
+  InternalServerError:
+    properties:
+      error:
+        type: string
+  GatewayTimeoutError:
+    properties:
+      error:
+        type: string
+  TvShowRequestBody:
+    properties:
+      tvdbId:
+        type: integer
+  TvShowsArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: TV Show id
+        name:
+          type: string
+          description: name of the TV Show
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+        score:
+          type: number
+          description: average rating
+        voteCount:
+          type: integer
+          description: number of ratings
+  TvdbTvShowsArray:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: TV Show id
+        tvdbId:
+          type: integer
+          description: TVDB id
+        name:
+          type: string
+          description: name of the TV Show
+        firstAired:
+          type: string
+          description: first aired date
+        banner:
+          type: string
+          description: relative url of the banner image
+        local:
+          type: boolean
+          description: true if the tvShows is in our bbdd
+        requested:
+          type: boolean
+          description: true if the tvShows is requested by users
+  TvShow:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: TV Show id
+      tvdbId:
+        type: integer
+        description: TV Show id on The TVDB API
+      name:
+        type: string
+        description: name of the TV Show
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the TV Show
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the TV Show airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the TV Show
+      rating:
+        type: string
+        description: TV Parental Guideline
+      status:
+        type: string
+        description: status of the TV Show (continuing or ended)
+      score:
+        type: number
+        description: average rating
+      voteCount:
+        type: integer
+        description: number of ratings
+      tvShowVotes:
+        type: array
+        items:
+          type: object
+          properties:
+            score:
+              type: number
+              description: score rating
+      seasons:
+        type: array
+        items:
+          type: object
+          properties:
+            id:
+              type: integer
+              description: season id
+            seasonNumber:
+              type: integer
+              description: season number
+            poster:
+              type: string
+              description: relative url of the season poster image
+  TvShowCreated:
+    type: object
+    properties:
+      ok:
+        type: string
+      banner:
+        type: boolean
+      poster:
+        type: boolean
+      fanart:
+        type: boolean
+      tvShow:
+        type: object
+        properties:
+          id:
+            type: integer
+            description: TV Show id
+          tvdbId:
+            type: integer
+            description: TV Show id on The TVDB API
+          name:
+            type: string
+            description: name of the TV Show
+          firstAired:
+            type: string
+            description: first aired date
+          overview:
+            type: string
+            description: a summary of the TV Show
+          banner:
+            type: string
+            description: relative url of the banner image
+          poster:
+            type: string
+            description: relative url of the poster image
+          fanart:
+            type: string
+            description: relative url of the fanart image
+          network:
+            type: string
+            description: network where the TV Show airs
+          runtime:
+            type: integer
+            description: average episode runtime
+          genre:
+            type: array
+            items:
+              type: string
+            description: genres of the TV Show
+          rating:
+            type: string
+            description: TV Parental Guideline
+          status:
+            type: string
+            description: status of the TV Show (continuing or ended)
+          score:
+            type: number
+            description: average rating
+          voteCount:
+            type: integer
+            description: number of ratings
+          tvShowVotes:
+            type: array
+            items:
+              type: object
+              properties:
+                score:
+                  type: number
+                  description: score rating
+          seasons:
+            type: array
+            items:
+              type: object
+              properties:
+                id:
+                  type: integer
+                  description: season id
+                seasonNumber:
+                  type: integer
+                  description: season number
+                poster:
+                  type: string
+                  description: relative url of the season poster image
+  TvShowBody:
+    type: object
+    properties:
+      name:
+        type: string
+        description: name of the TV Show
+      firstAired:
+        type: string
+        description: first aired date
+      overview:
+        type: string
+        description: a summary of the TV Show
+      banner:
+        type: string
+        description: relative url of the banner image
+      poster:
+        type: string
+        description: relative url of the poster image
+      fanart:
+        type: string
+        description: relative url of the fanart image
+      network:
+        type: string
+        description: network where the TV Show airs
+      runtime:
+        type: integer
+        description: average episode runtime
+      genre:
+        type: array
+        items:
+          type: string
+        description: genres of the TV Show
+      status:
+        type: string
+        description: status of the TV Show (continuing or ended)
+  TvShowUpdateBody:
+    type: object
+    properties:
+      update:
+        type: string
+        description: data or images
+  CompleteSeason:
+    type: object
+    properties:
+      id:
+        type: integer
+        description: season id
+      seasonNumber:
+        type: integer
+        description: season number
+      firstAired:
+        type: string
+        description: season first aired date
+      poster:
+        type: string
+        description: relative url of the season poster image
+      name:
+        type: string
+        description: season name
+      overview:
+        type: string
+        description: a summary of the season
+  ArraySimpleSeason:
+    type: array
+    items:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: season id
+        seasonNumber:
+          type: integer
+          description: season number
+        poster:
+          type: string
+          description: relative url of the season poster image
+  TvShowRating:
+    type: object
+    properties:
+      ok:
+        type: string
+      tvShowVote:
+        type: object
+        properties:
+          id:
+            type: integer
+          tvShowId:
+            type: integer
+          userId:
+            type: integer
+          score:
+            type: number
+  TvShowTvdb:
+    type: object
+    properties:
+      tvdbId:
+        type: integer
+        description: TVDB id
+      name:
+        type: string
+        description: name of the TV Show
+      firstAired:
+        type: string
+        description: first aired date
+      banner:
+        type: string
+        description: relative url of the banner image from TVDB
+  UserAuthenticated:
+    type: object
+    properties:
+      ok:
+        type: string
+        description: response
+      type:
+        type: string
+        description: response status
+      message:
+        type: string
+        description: response message
+      Authorization:
+        type: string
+        description: JWT generated
+      userId:
+        type: integer
+        description: user id
+      userName:
+        type: string
+        description: user name
+      userRol:
+        type: string
+        description: user rol
+  Evolutions:
+    type: object
+    properties:
+      evolutions:
+        type: object
+        properties:
+          id:
+            type: integer
+            description: id of the evolution
+          version:
+            type: integer
+            description: version of the evolution
+          state:
+            type: string
+            description: state of the evolution like not-applied, applied, etc.
+      actualVersion:
+        type: string
+        description: actual version of the database
+      newVersion:
+        type: string
+        description: new version to be applied if exists
+  EvolutionPatchBody:
+    properties:
+      evolutionId:
+        type: integer
+        description: id of the evolution to be applied
+  RatingPutBody:
+    properties:
+      score:
+        type: number
+        description: new TV Show rating
+  UserRegisterBody:
+    properties:
+      email:
+        type: string
+        description: new user's email
+      password:
+        type: string
+        description: SHA512 hashed password
+      name:
+        type: string
+        description: new user's name
+  UserAuthenticationBody:
+    properties:
+      email:
+        type: string
+        description: user's email
+      password:
+        type: string
+        description: SHA512 hashed password
+  RequestPatchBody:
+    properties:
+      status:
+        type: string
+        description: new request status
+securityDefinitions:
+  jwtAuth:
+    type: apiKey
+    in: header
+    name: Authorization

--- a/public/docs/index.html
+++ b/public/docs/index.html
@@ -74,7 +74,7 @@ window.onload = function() {
   
   // Build a system
   const ui = SwaggerUIBundle({
-    url: "./api-doc-versions/v0.10.0.yaml",
+    url: "./api-doc-versions/v0.10.7.yaml",
     docExpansion: 'none',
     dom_id: '#swagger-ui',
     deepLinking: true,


### PR DESCRIPTION
Rutas nuevas para obtener los datos de las temporadas de las series

```
/api/tvshows/{id}/seasons
/api/tvshows/{id}/seasons/{number}
```

Se requiere un controller para la función de estas routes.

Se requiere actualizar la documentación Swagger con las nuevas rutas y nuevas definiciones.