### PR TITLE
Mostrar y gestionar información episodios en Administración

### DIFF
--- a/app/views/administration/tvShow.scala.html
+++ b/app/views/administration/tvShow.scala.html
@@ -414,17 +414,22 @@
                 <div class="heading-btn pull-left">
                     <button data-id="@tvShow.id" data-action="download-data" data-host="@requestHeader.host" data-reload="@routes.AdminController.tvShow(tvShow.id)" type="button" class="btn bg-green btn-labeled">
                         <b><i class="icon-download"></i></b>
-                        Descargar datos de nuevo
+                        Redescargar datos
                     </button>
 
                     <button data-id="@tvShow.id" data-action="download-images" data-host="@requestHeader.host" data-reload="@routes.AdminController.tvShow(tvShow.id)" type="button" class="btn bg-green-600 btn-labeled">
                         <b><i class="icon-image2"></i></b>
-                        Descargar imágenes de nuevo
+                        Redescargar imágenes
                     </button>
 
                     <button data-id="@tvShow.id" data-action="download-seasons" data-host="@requestHeader.host" data-reload="@routes.AdminController.tvShow(tvShow.id)" type="button" class="btn bg-green-700 btn-labeled">
+                        <b><i class="icon-archive"></i></b>
+                        Redescargar temporadas
+                    </button>
+
+                    <button data-id="@tvShow.id" data-action="download-episodes" data-host="@requestHeader.host" data-reload="@routes.AdminController.tvShow(tvShow.id)" type="button" class="btn bg-green-800 btn-labeled">
                         <b><i class="icon-books"></i></b>
-                        Descargar temporadas de nuevo
+                        Redescargar episodios
                     </button>
                 </div>
 

--- a/app/views/administration/tvShow.scala.html
+++ b/app/views/administration/tvShow.scala.html
@@ -214,6 +214,11 @@
                                             <img class="smartphone-season-poster" src="@{ "http://".concat(requestHeader.host).concat("/assets/images/placeholderPoster.jpg") }" />
                                         }
                                             <div class="smartphone-season-title">Temporada @season.seasonNumber</div>
+                                            @if(season.episodes != null){
+                                                <div class="smartphone-season-subtitle">@season.episodes.size() episodios</div>
+                                            }else{
+                                                <div class="smartphone-season-subtitle">Sin episodios</div>
+                                            }
                                         </div>
                                     }
                                 }

--- a/app/views/administration/tvShow.scala.html
+++ b/app/views/administration/tvShow.scala.html
@@ -342,6 +342,56 @@
                             }else{
                                 <span>Sin sinopsis</span>
                             }
+
+                            <div class="season-episodes">
+                                @if(season.episodes != null && season.episodes.size() > 0) {
+                                    <h6><a data-toggle="collapse" href="#episodes-group-@season.seasonNumber"><strong>Episodios</strong> @season.episodes.size()</a></h6>
+                                    <div class="episodes collapse" id="episodes-group-@season.seasonNumber">
+                                    @for(episode <- season.episodes.sortBy(_.episodeNumber)) {
+                                        <div class="episode">
+                                            <div class="episode-screenshot">
+                                            @if(episode.screenshot != null) {
+                                                <a target="_blank" href="@{ "http://".concat(requestHeader.host).concat(episode.screenshot.substring(1)) }">
+                                                    <img class="episode-screenshot" src="@{ "http://".concat(requestHeader.host).concat(episode.screenshot.substring(1)) }" />
+                                                </a>
+                                            }else{
+                                                <img class="episode-screenshot" src="@{ "http://".concat(requestHeader.host).concat("/assets/images/placeholderPoster.jpg") }" />
+                                            }
+                                            </div>
+
+                                            <div class="episode-info">
+                                                <div class="episode-title">
+                                                    <div>
+                                                    @if(episode.name != null){
+                                                        <span class="episode-number">@episode.episodeNumber</span>
+                                                        <span class="episode-name">@episode.name</span>
+                                                    }else{
+                                                        <span class="episode-number">@episode.episodeNumber</span>
+                                                        <span class="episode-name"><span class="episode-number">Episodio @episode.episodeNumber</span>
+                                                    }
+                                                    </div>
+                                                @if(episode.firstAired != null){
+                                                    <span class="episode-firstAired">@episode.firstAired.format("dd-MM-yyyy")</span>
+                                                }else{
+                                                    <span class="episode-firstAired">Sin fecha</span>
+                                                }
+                                                </div>
+
+                                                <div>
+                                                @if(episode.overview != null){
+                                                    <span>@episode.overview</span>
+                                                }else{
+                                                    <span>Sin resumen</span>
+                                                }
+                                                </div>
+                                            </div>
+                                        </div>
+                                    }
+                                    </div>
+                                }else{
+                                    <h6>Sin episodios</h6>
+                                }
+                            </div>
                         </div>
                     </div>
                 }

--- a/public/javascripts/pages/tvShow.js
+++ b/public/javascripts/pages/tvShow.js
@@ -262,7 +262,8 @@ $(document).on('click', '[data-action=download-seasons]', function(e) {
 
   swal({
       title: 'Descargar temporadas',
-      text: '¿Seguro que quieres volver a descargar las temporadas? Lo demás se quedará como está.',
+      text: '¿Seguro que quieres volver a descargar las temporadas? Lo demás se quedará como está.\nEste proceso puede ' +
+      'durar unos minutos dependiendo de la cantidad de temporadas y episodios de la serie.',
       type: 'info',
       showCancelButton: true,
       closeOnConfirm: true,
@@ -311,6 +312,109 @@ $(document).on('click', '[data-action=download-seasons]', function(e) {
               swal({
                   title: 'Error',
                   text: 'No se ha podido descargar los datos de las temporadas en este momento',
+                  type: 'error',
+                  showCancelButton: false,
+                  closeOnConfirm: true,
+                  confirmButtonText: 'Aceptar'
+                },
+                function() {
+                  buttonIcon.attr('class', 'icon-download');
+                  $('#tvShow_panel').unblock();
+                });
+            }, 500);
+          }
+        });
+        promises.push(promise);
+
+        $.when.apply(null, promises).done(function() {
+          // redirigir...
+        });
+      } else {
+        // se ha cancelado el popup
+        $('#tvShow_panel').unblock();
+      }
+
+    });
+});
+
+// volver a descargar los episodios de todas las temporadas de la serie
+$(document).on('click', '[data-action=download-episodes]', function(e) {
+  console.log('redescargar episodios');
+  e.preventDefault();
+  let button = $(this);
+  let buttonIcon = $("i", this);
+  let tvShowId = button.attr('data-id');
+  let host = 'http://' + button.attr('data-host');
+  let redirect = button.attr('data-reload');
+  let htmlDataOk = '<i class="icon-checkmark4 text-green"></i>';
+  let htmlDataError = '<i class="icon-cross2 text-danger"></i>';
+
+  $('#tvShow_panel').block({
+    message: '<i class="icon-spinner9 spinner"></i>',
+    overlayCSS: {
+      backgroundColor: '#fff',
+      opacity: 0.8,
+      cursor: 'wait'
+    },
+    css: {
+      border: 0,
+      padding: 0,
+      backgroundColor: 'none'
+    }
+  });
+
+  swal({
+      title: 'Descargar episodios',
+      text: '¿Seguro que quieres volver a descargar los episodios? Lo demás se quedará como está.\nEste proceso puede ' +
+      'durar unos minutos dependiendo del número de episodios de la serie.',
+      type: 'info',
+      showCancelButton: true,
+      closeOnConfirm: true,
+      confirmButtonText: 'Aceptar',
+      cancelButtonText: 'Cancelar'
+    },
+    function(isConfirm) {
+      if (isConfirm) {
+        // cambiar estado
+        buttonIcon.attr('class', 'icon-spinner9 spinner');
+
+        // hacer peticion
+        var promises = [];
+        let promise = $.ajax({
+          url: host + '/api/tvshows/' + tvShowId,
+          type: 'PUT',
+          data: JSON.stringify({ "update": "seasons" }),
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer ' + window.localStorage.getItem('jwt')
+          },
+          success: function (response) {
+            if (response.ok !== null) {
+              console.log('serie actualizada, recargando...');
+              getRoute(redirect);
+            } else {
+              console.log("success - error persistiendo");
+              swal({
+                  title: 'Error',
+                  text: 'No se ha podido descargar los datos de la serie en este momento',
+                  type: 'error',
+                  showCancelButton: false,
+                  closeOnConfirm: true,
+                  confirmButtonText: 'Aceptar'
+                },
+                function() {
+                  buttonIcon.attr('class', 'icon-download');
+                  $('#tvShow_panel').unblock();
+                });
+            }
+          },
+          error: function (response) {
+            console.log("error - error persistiendo");
+            setTimeout(function() {
+              swal({
+                  title: 'Error',
+                  text: 'No se ha podido descargar los datos de los episodios en este momento',
                   type: 'error',
                   showCancelButton: false,
                   closeOnConfirm: true,

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -355,8 +355,13 @@
     padding: 0;
     padding-top: 30px;
     padding-bottom: 30px;
+    padding-right: 10px;
     margin: 0;
     border-bottom: 1px solid #e7e7e7;
+}
+
+.season:first-of-type {
+    padding-top: 15px;
 }
 
 .season:last-of-type {
@@ -384,6 +389,67 @@
 .season-info {
     padding-left: 30px;
     align-self: center;
+    width: 100%;
+}
+
+.season-episodes h6 {
+    margin-bottom: 6px;
+}
+
+.episodes {
+    padding: 10px;
+}
+
+.episode {
+    display: flex;
+    flex-direction: row;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    margin-bottom: 6px;
+}
+
+.episode:last-of-type {
+    margin-bottom: auto;
+}
+
+.episode-screenshot {
+    width: 150px;
+    height: auto;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    image-rendering: -webkit-optimize-contrast;
+    align-self: center;
+}
+
+.episode-info {
+    width: 100%;
+    align-self: center;
+    padding: 8px;
+    padding-left: 20px;
+}
+
+.episode-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    margin-bottom: 4px;
+    width: 100%;
+}
+
+.episode-name {
+    font-weight: 700;
+    font-size: 14px;
+}
+
+.episode-number {
+    margin-right: 4px;
+    font-size: 12px;
+    font-weight: 700;
+    color: #273246;
+}
+
+.episode-firstAired {
+    padding-right: 14px;
 }
 
 @media (max-width: 768px) {
@@ -402,6 +468,18 @@
 
     .season-info {
         padding-left: 0;
+    }
+
+    .episode {
+        flex-direction: column;
+    }
+
+    .episode-screenshot {
+        align-self: center;
+    }
+
+    .episode-title {
+        flex-direction: column;
     }
 }
 

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -337,7 +337,15 @@
 
 .smartphone-season-title {
     padding: 3px;
+    padding-bottom: 0;
     color: #eae5ec;
+}
+
+.smartphone-season-subtitle {
+    padding: 3px;
+    padding-top: 0;
+    color: #eae5ec;
+    opacity: 0.66;
 }
 
 /* información temporadas normal */


### PR DESCRIPTION
Mostrar un listado de los episodios de una temporada en la vista de una serie en concreto, de forma agrupada en cada temporada, con un botón de desplegar.

Añadir botón de redescargar los episodios.

Mostrar en previsualización móvil cuántos capítulos tiene cada temporada.