### PR TITLE
Mejorar seguridad contraseña

### DIFF
--- a/app/utils/Security/Password.java
+++ b/app/utils/Security/Password.java
@@ -1,6 +1,7 @@
 package utils.Security;
 
 import org.apache.commons.codec.binary.Base64;
+import play.Logger;
 
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
@@ -28,7 +29,9 @@ public class Password {
     }
   }
 
-  private static final String PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA1";
+  // java soporta hasta SHA512 (futuro SHA-3?)
+  private static final String PBKDF2_ALGORITHM = "PBKDF2WithHmacSHA512";
+  private static final String ALGORITHM = "SHA512";
 
   // constantes que pueden ser cambiadas
   private static final int SALT_BYTE_SIZE = 24;
@@ -60,9 +63,11 @@ public class Password {
     int hashSize = hash.length;
 
     // formato: algoritmo:iteraciones:tamañoHash:salt:hash
-    return "sha1:" +
+    return ALGORITHM.toLowerCase() +
+            ":" +
             PBKDF2_ITERATIONS +
-            ":" + hashSize +
+            ":" +
+            hashSize +
             ":" +
             Base64.encodeBase64String(salt) +
             ":" +
@@ -83,8 +88,8 @@ public class Password {
       throw new InvalidHashException("Fields are missing from the password hash.");
     }
 
-    // java solo soporta SHA1 de momento
-    if (!params[HASH_ALGORITHM_INDEX].equals("sha1")) {
+    // java solo soporta SHA512 de momento (a falta de SHA3)
+    if (!params[HASH_ALGORITHM_INDEX].equals(ALGORITHM.toLowerCase())) {
       throw new CannotPerformOperationException("Unsupported hash type.");
     }
 

--- a/test/utils/SecurityPasswordTest.java
+++ b/test/utils/SecurityPasswordTest.java
@@ -7,14 +7,14 @@ import utils.Security.Password;
 import static org.junit.Assert.*;
 
 public class SecurityPasswordTest {
-  private final String GOOD_PASSWORD = "123456";
-  private final String GOOD_PASSWORD_HASH = "sha1:64000:18:4lQrF5gzo3z+l6tsmdAuODQRmo6hGt0N:1wGzUmfWiwh2DUrPUhactIUJ";
-  private final String INVALID_SECTIONS_HASH = "sha1:64000:18:4lQrF5gzo3z+l6tsmdAuODQRmo6hGt0N";
-  private final String INVALID_TYPE_HASH = "sha2:64000:18:4lQrF5gzo3z+l6tsmdAuODQRmo6hGt0N:1wGzUmfWiwh2DUrPUhactIUJ";
-  private final String INVALID_ITERATION_HASH = "sha1:hola:18:4lQrF5gzo3z+l6tsmdAuODQRmo6hGt0N:1wGzUmfWiwh2DUrPUhactIUJ";
-  private final String INVALID_ITERATION_NUMBER_HASH = "sha1:0:18:4lQrF5gzo3z+l6tsmdAuODQRmo6hGt0N:1wGzUmfWiwh2DUrPUhactIUJ";
-  private final String INVALID_SECTION_SIZE_HASH = "sha1:64000:hola:4lQrF5gzo3z+l6tsmdAuODQRmo6hGt0N:1wGzUmfWiwh2DUrPUhactIUJ";
-  private final String INVALID_SIZE_HASH = "sha1:64000:18:4lQrF5gzo3z+l6tsmdAuODQRmo6hGt0N:1wGzUmfWiwhASDFASDFASDF2DUrPUhactIUJ";
+  private final String GOOD_PASSWORD = "BA3253876AED6BC22D4A6FF53D8406C6AD864195ED144AB5C87621B6C233B548BAEAE6956DF346EC8C17F5EA10F35EE3CBC514797ED7DDD3145464E2A0BAB413".toLowerCase();
+  private final String GOOD_PASSWORD_HASH = "sha512:64000:18:qJVfoLXprJGWy+Fmi2QqCqTmptxWWLT3:MtMGf4sQHQ7hqfQbX3iW5klV";
+  private final String INVALID_SECTIONS_HASH = "sha512:64000:18:qJVfoLXprJGWy+Fmi2QqCqTmptxWWLT3";
+  private final String INVALID_TYPE_HASH = "sha99:64000:18:qJVfoLXprJGWy+Fmi2QqCqTmptxWWLT3:MtMGf4sQHQ7hqfQbX3iW5klV";
+  private final String INVALID_ITERATION_HASH = "sha512:hola:18:qJVfoLXprJGWy+Fmi2QqCqTmptxWWLT3:MtMGf4sQHQ7hqfQbX3iW5klV";
+  private final String INVALID_ITERATION_NUMBER_HASH = "sha512:0:18:qJVfoLXprJGWy+Fmi2QqCqTmptxWWLT3:MtMGf4sQHQ7hqfQbX3iW5klV";
+  private final String INVALID_SECTION_SIZE_HASH = "sha512:64000:hola:qJVfoLXprJGWy+Fmi2QqCqTmptxWWLT3:MtMGf4sQHQ7hqfQbX3iW5klV";
+  private final String INVALID_SIZE_HASH = "sha512:64000:18:qJVfoLXprJGWy+Fmi2QqCqTmptxWWLT3:MtMGf4s_INVALIDO_QHQ7hqfQbX3iW5klV";
   private final String BAD_PASSWORD = "111111";
 
   private Password securityPassword = new Password();


### PR DESCRIPTION
Java ya soporta HMAC con SHA512 (una lástima que todavía no con SHA3) así que hay que actualizarlo ya que es una buena mejora.

Hay que refactorizar tests y resetear passwords actuales.